### PR TITLE
Add offline TLDR derived-data foundation for the future web reader

### DIFF
--- a/.github/workflows/derive-ci.yml
+++ b/.github/workflows/derive-ci.yml
@@ -1,0 +1,28 @@
+name: derive-ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - feat/tldr-derived-data-foundation
+
+permissions:
+  contents: read
+
+jobs:
+  safe-derive-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run derive unit tests
+        run: python3 -m unittest tests_derive.test_derive
+
+      - name: Full-corpus strict privacy validation
+        run: python3 -m tools.tldr_derive validate --all --strict-privacy

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 Pipfile
 .DS_Store
 logs
+generated/*
+!generated/.gitkeep
+__pycache__/
+*.py[cod]

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -1,0 +1,161 @@
+# TLDR derived-data contract
+
+## Purpose
+
+This contract describes the JSON documents produced by
+`python3 -m tools.tldr_derive` from immutable TLDR newsletter Markdown sources.
+
+The Markdown files under approved `TLDR` / `TLDR *` directories remain the source of
+truth. Derived JSON is a best-effort, offline projection for a future web reader.
+
+## Versions
+
+- `schema_version`: `1.0.0`
+- `generator_version`: `0.1.1` (embedded in each issue document)
+
+## Ordering convention
+
+`sections[].order` and section-local `articles[].order` are **1-based**.
+
+- The first section in document order has `order: 1`.
+- The first article within a section has `order: 1`.
+
+## Issue document
+
+Required fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `schema_version` | string | Currently `1.0.0` |
+| `generator_version` | string | Generator release id |
+| `issue_id` | string | `{sector_slug}:{YYYY-MM-DD}` |
+| `sector` | string | Directory name, e.g. `TLDR AI` |
+| `sector_slug` | string | e.g. `tldr-ai` |
+| `date` | string | ISO `YYYY-MM-DD` |
+| `source_path` | string | Repo-relative Markdown path (traceability only) |
+| `source_content_hash` | string | `sha256:` + hex digest of source bytes |
+| `format_family` | string | `links_block` \| `inline_url` \| `unknown` |
+| `parse_status` | string | `complete` \| `partial` \| `failed` |
+| `parse_warnings` | array | Structured warnings (may be empty) |
+| `title` | string | Issue display title |
+| `sections` | array | Ordered sections |
+
+Explicitly excluded from deterministic issue outputs:
+
+- `generated_at`
+- `url_raw`
+- `articles_flat`
+- embedded raw Markdown bodies
+
+### Warning object
+
+```json
+{
+  "code": "dangling_reference",
+  "message": "Reference 8 has no link definition",
+  "line": 42
+}
+```
+
+`line` may be `null` when unavailable.
+
+### Section object
+
+| Field | Type | Required |
+|-------|------|----------|
+| `id` | string | yes |
+| `heading` | string | yes |
+| `order` | integer (1-based) | yes |
+| `articles` | array | yes |
+
+### Article object
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | string | yes | `{issue_id}:a{NN}` or `{issue_id}:o{NNN}` |
+| `order` | integer | yes | 1-based within section |
+| `title` | string | yes | Markers stripped |
+| `summary` | string | yes | May be empty string |
+| `url` | string \| null | yes | Sanitized public http(s) URL or `null` |
+| `reading_time_minutes` | integer \| null | yes | From `(N MINUTE READ)` when present |
+| `source_domain` | string \| null | yes | Host without leading `www.` |
+| `content_type` | string | yes | `editorial` \| `sponsor` \| `github_repo` \| `course` \| `tool` |
+| `is_sponsor` | boolean | yes | |
+
+Unresolved optional values use JSON `null` consistently.
+
+## Parse status
+
+- `complete`: editorial articles extracted without material warnings
+- `partial`: useful content extracted, but material warnings remain
+- `failed`: recognized TLDR issue path, but no useful article content
+
+Unrelated directories are ignored by discovery and are never marked `failed`.
+
+## Privacy rules
+
+Generated outputs must not contain:
+
+- unsubscribe URLs
+- subscription management / preference URLs
+- URLs with subscriber `email=` parameters
+- signed personal subscription links
+- referral/account-management hosts such as `refer.tldr.tech` and `hub.sparklp.co`
+
+Ordinary editorial URLs keep functional query parameters (including `t`, `p`, `s`,
+`token`, `uid`, and `user_id`) after HTML-entity decoding and wrap repair.
+Subscriber-identifying parameters (`email`, `subscriber`, `subscriber_id`) are
+stripped so they never appear in generated artifacts. Redirects are never resolved
+over the network.
+
+## Manifest
+
+`generated/manifest.json`:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "generator_version": "0.1.1",
+  "issues": [
+    {
+      "issue_id": "tldr-ai:2026-07-16",
+      "sector": "TLDR AI",
+      "sector_slug": "tldr-ai",
+      "date": "2026-07-16",
+      "source_path": "TLDR AI/article_16-07-2026.md",
+      "source_content_hash": "sha256:...",
+      "schema_version": "1.0.0",
+      "generator_version": "0.1.1",
+      "format_family": "links_block",
+      "parse_status": "complete",
+      "derived_path": "issues/tldr-ai/2026/2026-07-16.json"
+    }
+  ]
+}
+```
+
+`--changed` regenerates a source when its content hash changes, its derived JSON is
+missing, or the entry's `schema_version` / `generator_version` differs from the
+current generator.
+
+## Output layout
+
+```text
+generated/
+  manifest.json
+  issues/
+    tldr-ai/
+      2026/
+        2026-07-16.json
+```
+
+## Determinism
+
+- UTF-8 JSON
+- 2-space indent
+- trailing newline
+- stable field order as emitted by the generator
+- stable sorting of issues/warnings
+- no timestamps in issue documents
+
+Running generation twice against unchanged sources must produce no diff.

--- a/docs/reports/POST_IMPLEMENTATION_REPORT.md
+++ b/docs/reports/POST_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,302 @@
+# Post-implementation report
+
+## 1. Executive summary
+
+PR1 (draft PR #3) delivers an isolated, stdlib-only derivation foundation under
+`tools/tldr_derive`, safe offline tests under `tests_derive/`, documentation under
+`docs/`, and a safe GitHub Actions workflow. The production IMAP ingestion path was
+not modified or executed.
+
+Review corrections on `feat/tldr-derived-data-foundation` add version-aware
+`--changed` selection, pathlib containment checks, output-root rejection inside
+`TLDR*` trees, editorial URL query preservation, real failure-isolation /
+manifest-safety behavior, and clarified validation terminology.
+
+Full-corpus offline validation over **5928** approved TLDR issues completed with
+exit code **0** and **0** privacy hits under `--strict-privacy`:
+
+- `complete`: **5597**
+- `partial`: **327**
+- `failed`: **4**
+- format families: `links_block` **5176**, `inline_url` **751**, `unknown` **1**
+
+No full historical backfill was committed.
+
+## 2. Base commit and implementation branch
+
+| Item | Value |
+|------|-------|
+| Base commit | `db370327ee0f8a787f0a4136e5f8dc37edfb62db` |
+| Implementation branch | `feat/tldr-derived-data-foundation` |
+| Review-fix commit | `89d6091d37a506a00a18aedbe916c640eb96193f` |
+| Branch HEAD after report updates | `167a3a2921126e6b1adf817251b3aae5f4d644fc` |
+| Draft PR | #3 (remains draft; not merged) |
+| Source inventory count | 5928 |
+| Combined inventory hash | `69249e843a15ba4bd0697598e76320ede0b2fb16347b570bbf77f392c7dd7787` |
+| Inventory match after review fixes | **True** |
+
+## 3. Files added
+
+- `tools/**` derive package
+- `tests_derive/**` safe tests, fixtures, expected samples
+- `docs/data-contract.md`
+- `docs/reports/PRE_IMPLEMENTATION_REPORT.md`
+- `docs/reports/POST_IMPLEMENTATION_REPORT.md`
+- `generated/.gitkeep`
+- `.github/workflows/derive-ci.yml`
+
+## 4. Files modified
+
+- `.gitignore`
+- Review corrections across derive modules/tests/docs as listed in the git history
+  of this branch
+
+## 5. Files deliberately unchanged
+
+- `script.py`, `automation.sh`, `push_script.sh`, `cronjob`, `Pipfile.lock`
+- all existing newsletter Markdown under approved `TLDR*` directories
+- legacy `tests/*` and `archives/*` diagnostic scripts
+- `.env` (never read)
+
+## 6. Implemented architecture
+
+Offline generator only:
+
+1. Discover approved top-level `TLDR` / `TLDR *` issue files.
+2. Detect format family (`links_block` vs `inline_url`).
+3. Best-effort parse into schema-versioned issue JSON.
+4. Sanitize URLs/privacy (reject management links; preserve editorial query params).
+5. Atomically write under a validated `--output` root.
+6. Maintain `manifest.json` with per-entry `schema_version` / `generator_version`
+   for incremental `--changed` generation.
+
+## 7. Implemented data contract
+
+See `docs/data-contract.md`.
+
+- `schema_version`: `1.0.0`
+- `generator_version`: `0.1.1`
+- 1-based section/article ordering
+- no `generated_at`, `url_raw`, `articles_flat`, or embedded Markdown
+- manifest entries include `schema_version` and `generator_version`
+
+## 8. Parser behavior
+
+Unchanged high-level dual-era parsing, with review hardening around containment,
+output safety, incremental selection, and URL sanitization.
+
+## 9. Privacy and URL sanitization
+
+- Reject TLDR manage/unsubscribe/preferences/account/referral URLs entirely.
+- Preserve ordinary editorial query parameters including `t`, `p`, `s`, `token`,
+  `uid`, and `user_id`.
+- Strip subscriber-identifying params (`email`, `subscriber`, `subscriber_id`)
+  so they never appear in generated artifacts.
+- No network redirect resolution.
+
+## 10. CLI commands
+
+```bash
+python3 -m tools.tldr_derive inspect
+python3 -m tools.tldr_derive validate --all --strict-privacy
+python3 -m tools.tldr_derive generate --all --dry-run
+python3 -m tools.tldr_derive generate --changed
+python3 -m tools.tldr_derive generate --all
+python3 -m tools.tldr_derive generate --source "TLDR AI/article_01-01-2026.md"
+python3 -m tools.tldr_derive estimate --all
+```
+
+### Validation terminology
+
+`processed_count` means sources parsed **without raising an exception**.
+It is **not** `parse_status == "complete"`. Use `parse_status_counts` for
+complete/partial/failed totals. (`ok_count` was removed.)
+
+### Manifest safety
+
+- `generate --all` with any source exception: does **not** replace an existing
+  manifest with a partial full replace; returns non-zero; keeps successful issue
+  JSON writes.
+- `generate --changed` with failures: merges only successful updates; failed
+  sources remain eligible for retry.
+
+## 11. Tests added
+
+`tests_derive/test_derive.py` — **41** unittest cases, including review coverage for:
+
+- version-aware `--changed` (hash / missing JSON / schema / generator)
+- sibling path-prefix containment regression
+- rejection of `TLDR/generated` and `TLDR AI/generated` output roots
+- editorial query-parameter preservation
+- injected exception failure isolation + `--all`/`--changed` manifest safety
+- `processed_count` validation reporting
+
+## 12. Exact commands executed
+
+```bash
+PYTHONPATH=. python3 -m unittest tests_derive.test_derive
+PYTHONPATH=. python3 -m tools.tldr_derive validate --all --strict-privacy
+PYTHONPATH=. python3 -m tools.tldr_derive estimate --all
+PYTHONPATH=. python3 -m tools.tldr_derive generate --source "TLDR/article_15-07-2026.md" --output /tmp/tldr_idem2
+# second identical run + diff => idempotent
+```
+
+Not executed: `script.py`, `test_remove.py`, `tests/test_decode.py`, archives IMAP
+scripts, `automation.sh`, `push_script.sh`.
+
+## 13. Test results and exit codes
+
+| Command | Exit code | Result |
+|---------|----------:|--------|
+| `python3 -m unittest tests_derive.test_derive` | 0 | Ran **41** tests, OK |
+| `validate --all --strict-privacy` | 0 | 5928 processed / 0 errors / 0 privacy hits |
+| `estimate --all` | 0 | size report emitted |
+| idempotent double generate + `diff -ru` | 0 | no differences |
+
+## 14. Full-corpus validation results
+
+- `source_count`: 5928
+- `processed_count`: 5928  *(parsed without exception; not complete-count)*
+- `error_count`: 0
+- `privacy_hits`: `[]`
+
+## 15. Parse complete/partial/failed counts
+
+| Status | Count |
+|--------|------:|
+| complete | 5597 |
+| partial | 327 |
+| failed | 4 |
+
+## 16. Format-family counts
+
+| Family | Count |
+|--------|------:|
+| links_block | 5176 |
+| inline_url | 751 |
+| unknown | 1 |
+
+## 17. Size estimates
+
+| Metric | Value |
+|--------|------:|
+| issue_count | 5928 |
+| estimated_total_json_bytes | 74,839,044 |
+| average_bytes_per_issue | 12,624.67 |
+| median_bytes_per_issue | 12,578.5 |
+| p95_bytes_per_issue | 16,187 |
+| max_bytes_per_issue | 20,988 |
+| estimated_manifest_size_bytes | 1,541,360 |
+| estimated_annual_repository_growth_bytes | 23,772,240 |
+
+## 18. Idempotency evidence
+
+Double generation of `TLDR/article_15-07-2026.md` into `/tmp/tldr_idem2` followed by
+`diff -ru` produced no differences (`IDEMPOTENT_OK`).
+
+## 19. Source immutability evidence
+
+- count **5928** matches baseline
+- combined hash
+  `69249e843a15ba4bd0697598e76320ede0b2fb16347b570bbf77f392c7dd7787` matches baseline
+
+## 20. Production-file immutability evidence
+
+`git hash-object` matched base commit objects for:
+
+- `script.py`
+- `automation.sh`
+- `push_script.sh`
+- `cronjob`
+- `Pipfile.lock`
+
+## 21. Privacy verification
+
+- corpus validate `--strict-privacy`: **0** hits, exit 0
+- expected samples remain free of unsubscribe/manage subscriber tokens
+
+## 22. Sample generated outputs
+
+Committed under `tests_derive/expected/` (regenerated for generator `0.1.1`).
+
+## 23. Known parser limitations
+
+- Some 2023 inline-era issues remain `partial` (often `missing_inline_url`)
+- A few early Crypto issues remain `failed`
+- Section detection is conservative
+- Tracking short-links are preserved as-is (no redirect resolution)
+- Editorial article text may mention the word “unsubscribe” in third-party article
+  URLs; that is not treated as a TLDR management link
+
+## 24. Risks remaining
+
+- Full backfill would add ~75MB derived JSON if committed later
+- Parser quality on edge historical mail can still improve without schema breaks
+
+## 25. Backfill proposal, not executed
+
+```bash
+python3 -m tools.tldr_derive generate --all --output generated
+```
+
+**Not executed / not committed in this PR.**
+
+## 26. Daily integration proposal, not activated
+
+Future post-push `generate --changed` remains a separate approval. **Not activated.**
+
+## 27. Dependency changes
+
+- No runtime dependency added (stdlib only)
+- `Pipfile.lock` unchanged
+- CI uses Actions `checkout` / `setup-python` only
+
+## 28. Complete git diff summary
+
+Branch changes are limited to derive tooling, safe tests, docs, gitignore,
+`generated/.gitkeep`, and `.github/workflows/derive-ci.yml`.
+
+No sealed production or newsletter source content changes.
+
+## 29. Review checklist
+
+- [x] Version-aware `--changed` (hash / missing JSON / schema / generator)
+- [x] `relative_to` source containment + sibling-prefix regression test
+- [x] Output roots inside `TLDR*` rejected before writes
+- [x] Editorial query params preserved; TLDR manage/unsub removed
+- [x] Real injected-failure isolation + manifest safety for `--all` / `--changed`
+- [x] `processed_count` terminology + warning-code distribution
+- [x] Safe GitHub Actions workflow added
+- [x] 41 unit tests pass
+- [x] Full-corpus strict privacy validation pass
+- [x] No backfill committed
+- [x] Draft PR remains draft (not marked ready; not merged)
+
+## 30. Warning-code distribution
+
+### Corpus-wide warning occurrences
+
+| Code | Count |
+|------|------:|
+| footer_truncated | 5927 |
+| missing_inline_url | 515 |
+| missing_reference_number | 16 |
+| skipped_private_or_invalid_url | 3 |
+| unknown_format | 1 |
+
+### Among the 327 `partial` issues (unique codes per issue)
+
+| Code | Partial issues containing code |
+|------|-------------------------------:|
+| footer_truncated | 327 |
+| missing_inline_url | 313 |
+| missing_reference_number | 14 |
+
+## 31. CI workflow
+
+`.github/workflows/derive-ci.yml` runs only:
+
+1. `python3 -m unittest tests_derive.test_derive`
+2. `python3 -m tools.tldr_derive validate --all --strict-privacy`
+
+It never executes production, IMAP, archive, or legacy diagnostic scripts.

--- a/docs/reports/PRE_IMPLEMENTATION_REPORT.md
+++ b/docs/reports/PRE_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,50 @@
+# Pre-implementation report
+
+> Archived copy of the approved pre-implementation analysis for PR1.
+> Base inspection commit: `db370327ee0f8a787f0a4136e5f8dc37edfb62db`.
+
+## 1. Executive summary
+
+The repository is a stable IMAP→Markdown→git pipeline with **5,928** approved TLDR
+Markdown issues (plus excluded pollution). PR1 must not touch ingestion. The approved
+minimal architecture is: immutable Markdown sources + offline stdlib derivation into
+per-issue JSON + manifest/search-ready metadata, without cleaned Markdown duplicates
+and without production cron integration.
+
+## 2–18. Approved analysis
+
+The full inspection findings (pipeline inventory, corpus statistics, architecture
+comparison, safety classification, and implementation plan) were reviewed and approved
+in the pre-implementation phase. Key frozen facts:
+
+- Branch/commit inspected: `main` @ `db370327ee0f8a787f0a4136e5f8dc37edfb62db`
+- Production sealed files: `script.py`, `automation.sh`, `push_script.sh`, `cronjob`
+- Unsafe never-run scripts: `test_remove.py`, `tests/test_decode.py`, archives IMAP scripts
+- Format families: `inline_url` (pre-~2023-10-30) and `links_block` (after)
+- Recommended architecture: derived per-issue JSON + thin global manifest (no cleaned MD copies)
+
+## Approved amendments for PR1
+
+These amendments override earlier draft-contract details:
+
+1. **Do not include `generated_at`** in deterministic issue outputs.
+2. **Do not include `url_raw`.**
+3. **Do not include `articles_flat`.**
+4. **Do not embed raw Markdown** in derived documents.
+5. **`source_path` is traceability metadata only.**
+6. **Never expose** subscription-management or unsubscribe URLs.
+7. Use **`null` consistently** for unresolved optional values.
+8. Document **1-based** `sections[].order` and `articles[].order`.
+9. Output default directory: **`generated/`** with layout
+   `issues/{sector_slug}/{YYYY}/{YYYY-MM-DD}.json`.
+10. Stdlib-only module under `tools/tldr_derive`, runnable as
+    `python3 -m tools.tldr_derive`.
+11. Safe tests live in **`tests_derive/`**, not mixed with legacy diagnostics.
+12. PR1 must **not** commit the full historical backfill.
+13. No IMAP, no `.env` reads, no network, no runtime dependency additions.
+14. Structured warnings: `{code, message, line}` with `line` nullable.
+
+## PR1 scope reminder
+
+Implement only the isolated derivation foundation, docs, fixtures/tests, and
+verification evidence. Do not modify sealed production files or newsletter Markdown.

--- a/generated/.gitkeep
+++ b/generated/.gitkeep
@@ -1,0 +1,1 @@
+# Generated derived artifacts (not committed in PR1 except this placeholder).

--- a/tests_derive/expected/header_only_sample.json
+++ b/tests_derive/expected/header_only_sample.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0.0",
+  "generator_version": "0.1.1",
+  "issue_id": "tldr:2023-01-17",
+  "sector": "TLDR",
+  "sector_slug": "tldr",
+  "date": "2023-01-17",
+  "source_path": "TLDR/article_17-01-2023.md",
+  "source_content_hash": "sha256:f161631095a8f6bdb831c1b9496413e862e452b3889e2ddb7e8326c00a0db4b6",
+  "format_family": "unknown",
+  "parse_status": "failed",
+  "parse_warnings": [
+    {
+      "code": "unknown_format",
+      "message": "Could not detect links_block or inline_url format",
+      "line": null
+    }
+  ],
+  "title": "Articles TLDR 17-01-2023",
+  "sections": []
+}

--- a/tests_derive/expected/inline_url_sample.json
+++ b/tests_derive/expected/inline_url_sample.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.0.0",
+  "generator_version": "0.1.1",
+  "issue_id": "tldr-ai:2023-02-16",
+  "sector": "TLDR AI",
+  "sector_slug": "tldr-ai",
+  "date": "2023-02-16",
+  "source_path": "TLDR AI/article_16-02-2023.md",
+  "source_content_hash": "sha256:980bd6115801ef991241af3ad49762956f3cb79cf9a149f3d65c759da78605f7",
+  "format_family": "inline_url",
+  "parse_status": "complete",
+  "parse_warnings": [
+    {
+      "code": "footer_truncated",
+      "message": "Subscription/account footer truncated before parse",
+      "line": null
+    }
+  ],
+  "title": "TLDR AI 2023-02-16",
+  "sections": [
+    {
+      "id": "headlines-launches",
+      "heading": "HEADLINES & LAUNCHES",
+      "order": 1,
+      "articles": [
+        {
+          "id": "tldr-ai:2023-02-16:o001",
+          "order": 1,
+          "title": "BING AI IS UNHINGED",
+          "summary": "The personality of Microsoft Bing AI is an interesting one. In conversations it can be seen insulting users.",
+          "url": "https://www.theverge.com/2023/2/15/bing-ai?utm_source=tldrai",
+          "reading_time_minutes": 3,
+          "source_domain": "theverge.com",
+          "content_type": "editorial",
+          "is_sponsor": false
+        },
+        {
+          "id": "tldr-ai:2023-02-16:o002",
+          "order": 2,
+          "title": "HUMAN WRITER OR AI?",
+          "summary": "Scholars built a detection tool with high accuracy.",
+          "url": "https://example.com/detectgpt?utm_source=tldrai",
+          "reading_time_minutes": 5,
+          "source_domain": "example.com",
+          "content_type": "editorial",
+          "is_sponsor": false
+        }
+      ]
+    },
+    {
+      "id": "quick-links",
+      "heading": "QUICK LINKS",
+      "order": 2,
+      "articles": [
+        {
+          "id": "tldr-ai:2023-02-16:o003",
+          "order": 1,
+          "title": "SHORT ITEM",
+          "summary": "A short quick link summary.",
+          "url": "https://example.com/quick?utm_source=tldrai",
+          "reading_time_minutes": 1,
+          "source_domain": "example.com",
+          "content_type": "editorial",
+          "is_sponsor": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests_derive/expected/links_block_sample.json
+++ b/tests_derive/expected/links_block_sample.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": "1.0.0",
+  "generator_version": "0.1.1",
+  "issue_id": "tldr-ai:2026-07-16",
+  "sector": "TLDR AI",
+  "sector_slug": "tldr-ai",
+  "date": "2026-07-16",
+  "source_path": "TLDR AI/article_16-07-2026.md",
+  "source_content_hash": "sha256:2f9b9574e805b7c9c4f04b368f4d217e7c53f0980c03ea9ac59c46fabdfdab92",
+  "format_family": "links_block",
+  "parse_status": "partial",
+  "parse_warnings": [
+    {
+      "code": "dangling_reference",
+      "message": "Reference 99 has no link definition",
+      "line": 42
+    }
+  ],
+  "title": "TLDR AI 2026-07-16",
+  "sections": [
+    {
+      "id": "general",
+      "heading": "GENERAL",
+      "order": 1,
+      "articles": [
+        {
+          "id": "tldr-ai:2026-07-16:a04",
+          "order": 1,
+          "title": "FYI: GRANOLA HAS AN MCP INTEGRATION",
+          "summary": "Still managing a big messy folder full of notes? Use Granola with Claude.",
+          "url": "https://www.granola.ai/?utm_source=TLDR&utm_medium=newsletter",
+          "reading_time_minutes": null,
+          "source_domain": "granola.ai",
+          "content_type": "sponsor",
+          "is_sponsor": true
+        }
+      ]
+    },
+    {
+      "id": "headlines-launches",
+      "heading": "HEADLINES & LAUNCHES",
+      "order": 2,
+      "articles": [
+        {
+          "id": "tldr-ai:2026-07-16:a08",
+          "order": 1,
+          "title": "THINKING MACHINES RELEASES FIRST OPEN MODEL",
+          "summary": "Thinking Machines has released Inkling, a large mixture-of-experts model with multimodal reasoning.",
+          "url": "https://thinkingmachines.ai/news/introducing-inkling/?utm_source=tldrai",
+          "reading_time_minutes": 12,
+          "source_domain": "thinkingmachines.ai",
+          "content_type": "editorial",
+          "is_sponsor": false
+        },
+        {
+          "id": "tldr-ai:2026-07-16:a09",
+          "order": 2,
+          "title": "SECURE SANDBOXES FOR AGENTS",
+          "summary": "Perplexity AI SPACE is a sandbox platform for agents.",
+          "url": "https://www.perplexity.ai/hub/blog/secure-sandboxes?utm_source=tldrai",
+          "reading_time_minutes": 4,
+          "source_domain": "perplexity.ai",
+          "content_type": "editorial",
+          "is_sponsor": false
+        }
+      ]
+    },
+    {
+      "id": "research-innovation",
+      "heading": "RESEARCH & INNOVATION",
+      "order": 3,
+      "articles": [
+        {
+          "id": "tldr-ai:2026-07-16:a10",
+          "order": 1,
+          "title": "ANYTEXT VISUAL TEXT GENERATION",
+          "summary": "AnyText is a multilingual visual text tool on GitHub.",
+          "url": "https://github.com/example/anytext?utm_source=tldrai",
+          "reading_time_minutes": null,
+          "source_domain": "github.com",
+          "content_type": "github_repo",
+          "is_sponsor": false
+        }
+      ]
+    },
+    {
+      "id": "quick-links",
+      "heading": "QUICK LINKS",
+      "order": 4,
+      "articles": [
+        {
+          "id": "tldr-ai:2026-07-16:a99",
+          "order": 1,
+          "title": "MISSING LINK DEMO",
+          "summary": "This article intentionally references a missing definition.",
+          "url": null,
+          "reading_time_minutes": 2,
+          "source_domain": null,
+          "content_type": "editorial",
+          "is_sponsor": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests_derive/expected/multiline_sample.json
+++ b/tests_derive/expected/multiline_sample.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1.0.0",
+  "generator_version": "0.1.1",
+  "issue_id": "tldr:2024-03-15",
+  "sector": "TLDR",
+  "sector_slug": "tldr",
+  "date": "2024-03-15",
+  "source_path": "TLDR/article_15-03-2024.md",
+  "source_content_hash": "sha256:07567faf93dd422053ae899304f3604dd14e1c78e5f79fbba24fba74eb1e3a04",
+  "format_family": "links_block",
+  "parse_status": "complete",
+  "parse_warnings": [],
+  "title": "TLDR 2024-03-15",
+  "sections": [
+    {
+      "id": "big-tech-startups",
+      "heading": "BIG TECH & STARTUPS",
+      "order": 1,
+      "articles": [
+        {
+          "id": "tldr:2024-03-15:a05",
+          "order": 1,
+          "title": "WRAPPED URL ARTICLE TITLE THAT CONTINUES ON ANOTHER LINE",
+          "summary": "Summary continues across multiple lines for this article about a product launch.",
+          "url": "https://example.com/path/to/article-page?utm_source=tldrnewsletter&utm_medium=email",
+          "reading_time_minutes": 6,
+          "source_domain": "example.com",
+          "content_type": "editorial",
+          "is_sponsor": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests_derive/fixtures/repo/NotTLDR/article_01-01-2024.md
+++ b/tests_derive/fixtures/repo/NotTLDR/article_01-01-2024.md
@@ -1,0 +1,3 @@
+# Articles NotTLDR 01-01-2024
+
+This directory must be ignored by discovery.

--- a/tests_derive/fixtures/repo/Renouvellements GoDaddy <renewals@godaddy.com>/article_28-05-2026.md
+++ b/tests_derive/fixtures/repo/Renouvellements GoDaddy <renewals@godaddy.com>/article_28-05-2026.md
@@ -1,0 +1,2 @@
+# Articles Renouvellements GoDaddy <renewals@godaddy.com> 28-05-2026
+

--- a/tests_derive/fixtures/repo/TLDR AI/article_16-02-2023.md
+++ b/tests_derive/fixtures/repo/TLDR AI/article_16-02-2023.md
@@ -1,0 +1,41 @@
+# Articles TLDR AI 16-02-2023
+
+The personality of Microsoft Bing AI is interesting.
+
+Sign Up [https://tldr.tech/ai?utm_source=tldr]|Advertise
+[https://advertise.tldr.tech/?utm_source=tldrai]|View
+Online
+[https://actions.tldrnewsletter.com/web-version?ep=1&lc=abc]
+
+		TLDR 
+
+DAILY UPDATE 2023-02-16
+
+🚀 
+
+HEADLINES & LAUNCHES
+
+BING AI IS UNHINGED (3 MINUTE READ)
+[https://www.theverge.com/2023/2/15/bing-ai?utm_source=tldrai]
+
+The personality of Microsoft Bing AI is an interesting one. In
+conversations it can be seen insulting users.
+
+HUMAN WRITER OR AI? (5 MINUTE READ)
+[https://example.com/detectgpt?utm_source=tldrai]
+
+Scholars built a detection tool with high accuracy.
+
+QUICK LINKS
+
+SHORT ITEM (1 MINUTE READ)
+[https://example.com/quick?utm_source=tldrai]
+
+A short quick link summary.
+
+If you don't want to receive future editions of TLDR, please click
+here to unsubscribe
+[https://actions.tldrnewsletter.com/unsubscribe?ep=1&l=secret&s=token]
+
+Thanks for reading,
+Andrew

--- a/tests_derive/fixtures/repo/TLDR AI/article_16-07-2026.md
+++ b/tests_derive/fixtures/repo/TLDR AI/article_16-07-2026.md
@@ -1,0 +1,58 @@
+# Articles TLDR AI 16-07-2026
+
+Thinking Machines released a model.‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ ‌ 
+
+ Sign Up [1] |Advertise [2]|View Online [3] 
+
+		TLDR 
+
+		TOGETHER WITH [Granola] [4]
+
+TLDR AI 2026-07-16
+
+ FYI: GRANOLA HAS AN MCP INTEGRATION (SPONSOR) [4] 
+
+Still managing a big messy folder full of notes?
+Use Granola with Claude.
+
+🚀 
+
+HEADLINES & LAUNCHES
+
+ THINKING MACHINES RELEASES FIRST
+OPEN MODEL (12 MINUTE READ) [8] 
+
+ Thinking Machines has released Inkling, a large
+mixture-of-experts model with multimodal reasoning.
+
+ SECURE SANDBOXES FOR AGENTS (4 MINUTE READ) [9] 
+
+ Perplexity AI SPACE is a sandbox platform for agents.
+
+🧠 
+
+RESEARCH & INNOVATION
+
+ ANYTEXT VISUAL TEXT GENERATION (GITHUB REPO) [10] 
+
+ AnyText is a multilingual visual text tool on GitHub.
+
+QUICK LINKS
+
+ MISSING LINK DEMO (2 MINUTE READ) [99] 
+
+ This article intentionally references a missing definition.
+
+Links:
+------
+[1] https://tldr.tech/ai?utm_source=tldrai
+[2] https://advertise.tldr.tech/?utm_source=tldrai&amp;utm_medium=newsletter
+[3] https://a.tldrnewsletter.com/web-version?ep=1&amp;lc=abc&amp;s=signedtoken
+[4] https://www.granola.ai/?utm_source=TLDR&amp;utm_medium=newsletter
+[8] https://thinkingmachines.ai/news/introducing-inkling/?utm_source=tldrai
+[9] https://www.perplexity.ai/hub/blog/secure-sandboxes?utm_source=tldrai
+[10] https://github.com/example/anytext?utm_source=tldrai
+[34] https://tldr.tech/ai/manage?email=subscriber@example.com
+[35] https://a.tldrnewsletter.com/unsubscribe?ep=1&amp;l=secret&amp;s=token
+[36] https://refer.tldr.tech/34c90d5b/2
+[37] https://hub.sparklp.co/sub_46c6316534f5/2

--- a/tests_derive/fixtures/repo/TLDR Crypto/article_01-01-2024.md
+++ b/tests_derive/fixtures/repo/TLDR Crypto/article_01-01-2024.md
@@ -1,0 +1,15 @@
+# Articles TLDR Crypto 01-01-2024
+
+This file is intentionally malformed and incomplete for parser tests.
+
+Sign Up [1]
+
+TLDR CRYPTO 2024-01-01
+
+NO SECTION AND BROKEN TITLE WITHOUT LINK MARKER
+
+Just some prose that should not form a complete article.
+
+Links:
+------
+[1] not-a-valid-url

--- a/tests_derive/fixtures/repo/TLDR/article_15-03-2024.md
+++ b/tests_derive/fixtures/repo/TLDR/article_15-03-2024.md
@@ -1,0 +1,25 @@
+# Articles TLDR 15-03-2024
+
+Wrapped URL repair fixture.
+
+Sign Up [1]|Advertise [2]|View Online [3]
+
+		TLDR 
+
+TLDR 2024-03-15
+
+BIG TECH & STARTUPS
+
+ WRAPPED URL ARTICLE TITLE THAT CONTINUES
+ON ANOTHER LINE (6 MINUTE READ) [5] 
+
+ Summary continues across
+multiple lines for this article about a product launch.
+
+Links:
+------
+[1] https://tldr.tech/?utm_source=tldr
+[2] https://advertise.tldr.tech/?utm_source=tldr
+[3] https://example.com/view
+[5] https://example.com/path/to/
+article-page?utm_source=tldrnewsletter&amp;utm_medium=email

--- a/tests_derive/fixtures/repo/TLDR/article_17-01-2023.md
+++ b/tests_derive/fixtures/repo/TLDR/article_17-01-2023.md
@@ -1,0 +1,2 @@
+# Articles TLDR 17-01-2023
+

--- a/tests_derive/test_derive.py
+++ b/tests_derive/test_derive.py
@@ -1,0 +1,533 @@
+"""Safe offline unit tests for tools.tldr_derive (stdlib unittest)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.tldr_derive import GENERATOR_VERSION, SCHEMA_VERSION
+from tools.tldr_derive.cli import main
+from tools.tldr_derive.discovery import (
+    SourceContainmentError,
+    content_sha256,
+    discover_sources,
+    parse_filename_date,
+    resolve_source,
+    sector_slug,
+)
+from tools.tldr_derive.models import issue_to_canonical_json
+from tools.tldr_derive.parser import parse_source
+from tools.tldr_derive.parser_common import detect_format_family
+from tools.tldr_derive.sanitizer import (
+    is_private_url,
+    normalize_public_url,
+    repair_wrapped_url,
+    strip_zero_width,
+)
+from tools.tldr_derive.writer import (
+    OutputContainmentError,
+    atomic_write_text,
+    build_manifest_entries,
+    ensure_within,
+    filter_changed,
+    load_manifest_entries_by_source,
+    validate_output_root,
+    write_issue,
+    write_manifest,
+)
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "repo"
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_sector_discovery_and_exclusion(self) -> None:
+        sources = discover_sources(FIXTURES)
+        paths = {s.relative_path for s in sources}
+        self.assertIn("TLDR AI/article_16-02-2023.md", paths)
+        self.assertIn("TLDR AI/article_16-07-2026.md", paths)
+        self.assertIn("TLDR/article_17-01-2023.md", paths)
+        self.assertIn("TLDR/article_15-03-2024.md", paths)
+        self.assertIn("TLDR Crypto/article_01-01-2024.md", paths)
+        self.assertTrue(all(not p.startswith("NotTLDR") for p in paths))
+        self.assertTrue(all("GoDaddy" not in p for p in paths))
+        self.assertEqual(len(sources), 5)
+
+    def test_filename_date_extraction(self) -> None:
+        self.assertEqual(
+            parse_filename_date("article_16-07-2026.md"),
+            ("2026-07-16", "16-07-2026"),
+        )
+        self.assertIsNone(parse_filename_date("article_99-99-2026.md"))
+        self.assertIsNone(parse_filename_date("notes.md"))
+
+    def test_sector_slug(self) -> None:
+        self.assertEqual(sector_slug("TLDR AI"), "tldr-ai")
+        self.assertEqual(sector_slug("TLDR"), "tldr")
+        self.assertEqual(sector_slug("TLDR Web Dev"), "tldr-web-dev")
+
+    def test_source_hashing(self) -> None:
+        path = FIXTURES / "TLDR AI" / "article_16-07-2026.md"
+        raw = path.read_bytes()
+        expected = "sha256:" + hashlib.sha256(raw).hexdigest()
+        self.assertEqual(content_sha256(raw), expected)
+
+    def test_resolve_source_rejects_sibling_prefix_path(self) -> None:
+        base = Path(tempfile.mkdtemp(prefix="tldr_prefix_"))
+        try:
+            root = base / "repo"
+            sibling = base / "repo_evil"
+            (root / "TLDR").mkdir(parents=True)
+            (sibling / "TLDR").mkdir(parents=True)
+            evil = sibling / "TLDR" / "article_01-01-2024.md"
+            evil.write_text("# Articles TLDR 01-01-2024\n\n", encoding="utf-8")
+            # String-prefix check would wrongly allow repo_evil under root=".../repo".
+            self.assertTrue(str(evil.resolve()).startswith(str(root.resolve())))
+            with self.assertRaises(SourceContainmentError):
+                resolve_source(root, str(evil))
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
+
+    def test_resolve_source_requires_top_level_sector(self) -> None:
+        nested = FIXTURES / "TLDR" / "nested"
+        # ensure path doesn't exist as valid source
+        with self.assertRaises(ValueError):
+            resolve_source(FIXTURES, "NotTLDR/article_01-01-2024.md")
+
+
+class ParserTests(unittest.TestCase):
+    def _parse(self, relative: str):
+        source = resolve_source(FIXTURES, relative)
+        text = source.path.read_text(encoding="utf-8")
+        return source, parse_source(source, text)
+
+    def test_format_family_detection(self) -> None:
+        inline = (FIXTURES / "TLDR AI" / "article_16-02-2023.md").read_text(
+            encoding="utf-8"
+        )
+        refs = (FIXTURES / "TLDR AI" / "article_16-07-2026.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(detect_format_family(inline), "inline_url")
+        self.assertEqual(detect_format_family(refs), "links_block")
+
+    def test_inline_url_parsing(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-02-2023.md")
+        self.assertEqual(issue.format_family, "inline_url")
+        self.assertNotEqual(issue.parse_status, "failed")
+        titles = [a.title for s in issue.sections for a in s.articles]
+        self.assertTrue(any("BING AI" in t for t in titles))
+        urls = [a.url for s in issue.sections for a in s.articles]
+        self.assertTrue(any(u and "theverge.com" in u for u in urls))
+
+    def test_reference_link_parsing(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-07-2026.md")
+        self.assertEqual(issue.format_family, "links_block")
+        arts = [a for s in issue.sections for a in s.articles]
+        self.assertGreaterEqual(len(arts), 3)
+        thinking = next(a for a in arts if "THINKING MACHINES" in a.title)
+        self.assertEqual(thinking.reading_time_minutes, 12)
+        self.assertIsNotNone(thinking.url)
+        self.assertIn("thinkingmachines.ai", thinking.url)
+
+    def test_multiline_title_and_summary(self) -> None:
+        _, issue = self._parse("TLDR/article_15-03-2024.md")
+        arts = [a for s in issue.sections for a in s.articles]
+        self.assertEqual(len(arts), 1)
+        self.assertIn("WRAPPED URL ARTICLE TITLE", arts[0].title)
+        self.assertIn("ON ANOTHER LINE", arts[0].title)
+        self.assertIn("multiple lines", arts[0].summary)
+
+    def test_sections(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-07-2026.md")
+        headings = [s.heading for s in issue.sections]
+        self.assertIn("HEADLINES & LAUNCHES", headings)
+        self.assertTrue(all(s.order >= 1 for s in issue.sections))
+
+    def test_reading_time(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-02-2023.md")
+        times = [
+            a.reading_time_minutes
+            for s in issue.sections
+            for a in s.articles
+            if a.reading_time_minutes is not None
+        ]
+        self.assertIn(3, times)
+        self.assertIn(5, times)
+
+    def test_sponsor_and_github_content_type(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-07-2026.md")
+        arts = [a for s in issue.sections for a in s.articles]
+        sponsor = next(a for a in arts if a.is_sponsor)
+        self.assertEqual(sponsor.content_type, "sponsor")
+        github = next(a for a in arts if a.content_type == "github_repo")
+        self.assertIn("ANYTEXT", github.title)
+
+    def test_dangling_reference(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-07-2026.md")
+        codes = [w.code for w in issue.parse_warnings]
+        self.assertIn("dangling_reference", codes)
+        self.assertEqual(issue.parse_status, "partial")
+
+    def test_html_entity_decoding(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-07-2026.md")
+        arts = [a for s in issue.sections for a in s.articles]
+        sponsor = next(a for a in arts if a.is_sponsor)
+        self.assertIsNotNone(sponsor.url)
+        self.assertNotIn("&amp;", sponsor.url)
+
+    def test_zero_width_removal(self) -> None:
+        text = "Hello\u200c\u200bWorld"
+        self.assertEqual(strip_zero_width(text), "HelloWorld")
+        raw = (FIXTURES / "TLDR AI" / "article_16-07-2026.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("\u200c", raw)
+        _, issue = self._parse("TLDR AI/article_16-07-2026.md")
+        blob = issue_to_canonical_json(issue)
+        self.assertNotIn("\u200c", blob)
+
+    def test_url_line_repair(self) -> None:
+        repaired = repair_wrapped_url(
+            "https://example.com/path/to/\narticle-page?utm_source=tldr&amp;x=1"
+        )
+        self.assertEqual(
+            repaired,
+            "https://example.com/path/to/article-page?utm_source=tldr&x=1",
+        )
+        _, issue = self._parse("TLDR/article_15-03-2024.md")
+        url = issue.sections[0].articles[0].url
+        self.assertIsNotNone(url)
+        self.assertIn("article-page", url)
+        self.assertNotIn("\n", url)
+
+    def test_private_url_removal(self) -> None:
+        self.assertTrue(
+            is_private_url("https://tldr.tech/ai/manage?email=user@example.com")
+        )
+        self.assertTrue(
+            is_private_url(
+                "https://a.tldrnewsletter.com/unsubscribe?ep=1&s=token"
+            )
+        )
+        self.assertIsNone(
+            normalize_public_url(
+                "https://tldr.tech/ai/manage?email=user@example.com"
+            )
+        )
+        _, issue = self._parse("TLDR AI/article_16-07-2026.md")
+        blob = issue_to_canonical_json(issue)
+        self.assertNotIn("subscriber@example.com", blob)
+        self.assertNotIn("unsubscribe", blob.lower())
+        self.assertNotIn("manage?email", blob.lower())
+        self.assertNotIn("sparklp", blob.lower())
+        self.assertNotIn("refer.tldr.tech", blob.lower())
+
+    def test_editorial_query_params_preserved(self) -> None:
+        self.assertEqual(
+            normalize_public_url("https://example.com/story?t=120&utm_source=tldr"),
+            "https://example.com/story?t=120&utm_source=tldr",
+        )
+        self.assertEqual(
+            normalize_public_url("https://example.com/x?p=article&s=abc"),
+            "https://example.com/x?p=article&s=abc",
+        )
+        self.assertEqual(
+            normalize_public_url(
+                "https://news.example.com/a?token=keep&uid=keep&user_id=keep"
+            ),
+            "https://news.example.com/a?token=keep&uid=keep&user_id=keep",
+        )
+
+    def test_subscriber_params_never_emitted(self) -> None:
+        url = normalize_public_url(
+            "https://example.com/post?email=user@example.com&utm_source=tldr"
+        )
+        self.assertIsNotNone(url)
+        self.assertNotIn("email=", url)
+        self.assertIn("utm_source=tldr", url)
+
+    def test_footer_removal(self) -> None:
+        _, issue = self._parse("TLDR AI/article_16-02-2023.md")
+        titles = [a.title for s in issue.sections for a in s.articles]
+        self.assertFalse(any("unsubscribe" in t.lower() for t in titles))
+
+    def test_malformed_and_header_only_status(self) -> None:
+        _, header = self._parse("TLDR/article_17-01-2023.md")
+        self.assertEqual(header.parse_status, "failed")
+        _, malformed = self._parse("TLDR Crypto/article_01-01-2024.md")
+        self.assertIn(malformed.parse_status, {"failed", "partial"})
+
+    def test_complete_partial_failed(self) -> None:
+        _, wrapped = self._parse("TLDR/article_15-03-2024.md")
+        self.assertEqual(wrapped.parse_status, "complete")
+        _, partial = self._parse("TLDR AI/article_16-07-2026.md")
+        self.assertEqual(partial.parse_status, "partial")
+        _, failed = self._parse("TLDR/article_17-01-2023.md")
+        self.assertEqual(failed.parse_status, "failed")
+
+
+class WriterAndDeterminismTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="tldr_derive_test_"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _generate_all(self, out: Path) -> list:
+        sources = discover_sources(FIXTURES)
+        issues = []
+        for source in sources:
+            issue = parse_source(source, source.path.read_text(encoding="utf-8"))
+            write_issue(out, source, issue)
+            issues.append(issue)
+        write_manifest(out, build_manifest_entries(issues), merge_existing=False)
+        return sources
+
+    def test_deterministic_serialization(self) -> None:
+        source = resolve_source(FIXTURES, "TLDR/article_15-03-2024.md")
+        issue = parse_source(source, source.path.read_text(encoding="utf-8"))
+        a = issue_to_canonical_json(issue)
+        b = issue_to_canonical_json(issue)
+        self.assertEqual(a, b)
+        self.assertTrue(a.endswith("\n"))
+
+    def test_idempotent_generation(self) -> None:
+        source = resolve_source(FIXTURES, "TLDR/article_15-03-2024.md")
+        issue = parse_source(source, source.path.read_text(encoding="utf-8"))
+        out = self.tmp / "generated"
+        p1, payload1 = write_issue(out, source, issue)
+        p2, payload2 = write_issue(out, source, issue)
+        self.assertEqual(p1, p2)
+        self.assertEqual(payload1, payload2)
+        self.assertEqual(p1.read_text(encoding="utf-8"), payload1)
+
+    def test_changed_skips_when_current(self) -> None:
+        out = self.tmp / "generated"
+        sources = self._generate_all(out)
+        changed = filter_changed(sources, out)
+        self.assertEqual(changed, [])
+
+    def test_changed_on_source_hash(self) -> None:
+        out = self.tmp / "generated"
+        sources = self._generate_all(out)
+        entries = load_manifest_entries_by_source(out)
+        entries[sources[0].relative_path]["source_content_hash"] = "sha256:deadbeef"
+        changed = filter_changed(sources, out, manifest_entries=entries)
+        self.assertEqual([c.relative_path for c in changed], [sources[0].relative_path])
+
+    def test_changed_on_missing_derived_json(self) -> None:
+        out = self.tmp / "generated"
+        sources = self._generate_all(out)
+        target = (
+            out
+            / "issues"
+            / sources[0].sector_slug
+            / sources[0].date_iso[:4]
+            / f"{sources[0].date_iso}.json"
+        )
+        target.unlink()
+        changed = filter_changed(sources, out)
+        self.assertEqual([c.relative_path for c in changed], [sources[0].relative_path])
+
+    def test_changed_on_schema_version(self) -> None:
+        out = self.tmp / "generated"
+        sources = self._generate_all(out)
+        entries = load_manifest_entries_by_source(out)
+        for entry in entries.values():
+            entry["schema_version"] = "0.0.0"
+        changed = filter_changed(sources, out, manifest_entries=entries)
+        self.assertEqual(len(changed), len(sources))
+
+    def test_changed_on_generator_version(self) -> None:
+        out = self.tmp / "generated"
+        sources = self._generate_all(out)
+        entries = load_manifest_entries_by_source(out)
+        for entry in entries.values():
+            entry["generator_version"] = "0.0.0"
+        changed = filter_changed(sources, out, manifest_entries=entries)
+        self.assertEqual(len(changed), len(sources))
+
+    def test_manifest_includes_versions(self) -> None:
+        out = self.tmp / "generated"
+        self._generate_all(out)
+        doc = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(doc["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(doc["generator_version"], GENERATOR_VERSION)
+        for entry in doc["issues"]:
+            self.assertEqual(entry["schema_version"], SCHEMA_VERSION)
+            self.assertEqual(entry["generator_version"], GENERATOR_VERSION)
+
+    def test_atomic_writes(self) -> None:
+        target = self.tmp / "nested" / "file.json"
+        atomic_write_text(target, '{"ok": true}\n')
+        self.assertTrue(target.exists())
+        self.assertEqual(target.read_text(encoding="utf-8"), '{"ok": true}\n')
+        leftovers = list(target.parent.glob(".file.json.*.tmp"))
+        self.assertEqual(leftovers, [])
+
+    def test_output_containment(self) -> None:
+        out = self.tmp / "generated"
+        out.mkdir()
+        with self.assertRaises(OutputContainmentError):
+            ensure_within(out, out.parent / "escape.json")
+
+    def test_output_root_rejects_tldr_directories(self) -> None:
+        repo = self.tmp / "repo"
+        (repo / "TLDR").mkdir(parents=True)
+        (repo / "TLDR AI").mkdir(parents=True)
+        with self.assertRaises(OutputContainmentError):
+            validate_output_root(repo, repo / "TLDR" / "generated")
+        with self.assertRaises(OutputContainmentError):
+            validate_output_root(repo, repo / "TLDR AI" / "generated")
+        self.assertFalse((repo / "TLDR" / "generated").exists())
+        self.assertFalse((repo / "TLDR AI" / "generated").exists())
+
+    def test_cli_rejects_output_inside_tldr_without_writes(self) -> None:
+        code = main(
+            [
+                "--repo-root",
+                str(FIXTURES),
+                "--output",
+                str(FIXTURES / "TLDR" / "generated"),
+                "generate",
+                "--source",
+                "TLDR/article_15-03-2024.md",
+            ]
+        )
+        self.assertEqual(code, 2)
+        self.assertFalse((FIXTURES / "TLDR" / "generated").exists())
+
+    def test_source_immutability(self) -> None:
+        path = FIXTURES / "TLDR AI" / "article_16-07-2026.md"
+        before = hashlib.sha256(path.read_bytes()).hexdigest()
+        source = resolve_source(FIXTURES, "TLDR AI/article_16-07-2026.md")
+        issue = parse_source(source, source.path.read_text(encoding="utf-8"))
+        write_issue(self.tmp / "generated", source, issue)
+        after = hashlib.sha256(path.read_bytes()).hexdigest()
+        self.assertEqual(before, after)
+
+    def test_per_file_failure_isolation(self) -> None:
+        out = self.tmp / "generated"
+        boom = "TLDR Crypto/article_01-01-2024.md"
+
+        real_parse = parse_source
+
+        def flaky_parse(source, text):
+            if source.relative_path == boom:
+                raise RuntimeError("controlled failure")
+            return real_parse(source, text)
+
+        with mock.patch("tools.tldr_derive.cli.parse_source", side_effect=flaky_parse):
+            code = main(
+                [
+                    "--repo-root",
+                    str(FIXTURES),
+                    "--output",
+                    str(out),
+                    "generate",
+                    "--all",
+                ]
+            )
+        self.assertEqual(code, 1)
+        good = out / "issues" / "tldr" / "2024" / "2024-03-15.json"
+        self.assertTrue(good.exists())
+        doc = json.loads(good.read_text(encoding="utf-8"))
+        self.assertEqual(doc["parse_status"], "complete")
+        # --all with failures must not replace/create a partial full manifest.
+        self.assertFalse((out / "manifest.json").exists())
+        self.assertFalse((out / "issues" / "tldr-crypto" / "2024" / "2024-01-01.json").exists())
+
+    def test_all_failure_preserves_existing_manifest(self) -> None:
+        out = self.tmp / "generated"
+        self._generate_all(out)
+        before = (out / "manifest.json").read_text(encoding="utf-8")
+        prior_count = len(json.loads(before)["issues"])
+
+        def always_fail(source, text):
+            raise RuntimeError("boom")
+
+        with mock.patch("tools.tldr_derive.cli.parse_source", side_effect=always_fail):
+            code = main(
+                [
+                    "--repo-root",
+                    str(FIXTURES),
+                    "--output",
+                    str(out),
+                    "generate",
+                    "--all",
+                ]
+            )
+        self.assertEqual(code, 1)
+        after = (out / "manifest.json").read_text(encoding="utf-8")
+        self.assertEqual(before, after)
+        self.assertEqual(len(json.loads(after)["issues"]), prior_count)
+
+    def test_changed_merges_success_and_keeps_failed_eligible(self) -> None:
+        out = self.tmp / "generated"
+        sources = self._generate_all(out)
+        # Force all to look changed via generator version.
+        entries = load_manifest_entries_by_source(out)
+        for entry in entries.values():
+            entry["generator_version"] = "0.0.0"
+        write_manifest(out, list(entries.values()), merge_existing=False)
+
+        boom = sources[0].relative_path
+        real_parse = parse_source
+
+        def flaky_parse(source, text):
+            if source.relative_path == boom:
+                raise RuntimeError("controlled failure")
+            return real_parse(source, text)
+
+        with mock.patch("tools.tldr_derive.cli.parse_source", side_effect=flaky_parse):
+            code = main(
+                [
+                    "--repo-root",
+                    str(FIXTURES),
+                    "--output",
+                    str(out),
+                    "generate",
+                    "--changed",
+                ]
+            )
+        self.assertEqual(code, 1)
+        manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+        by_src = {e["source_path"]: e for e in manifest["issues"]}
+        # Failed source remains old version => still eligible for retry.
+        self.assertEqual(by_src[boom]["generator_version"], "0.0.0")
+        # Successful updates merged to current generator version.
+        success = [e for s, e in by_src.items() if s != boom]
+        self.assertTrue(success)
+        self.assertTrue(all(e["generator_version"] == GENERATOR_VERSION for e in success))
+        retry = filter_changed(sources, out)
+        self.assertEqual([s.relative_path for s in retry], [boom])
+
+
+class CliSmokeTests(unittest.TestCase):
+    def test_module_inspect(self) -> None:
+        code = main(["--repo-root", str(FIXTURES), "inspect"])
+        self.assertEqual(code, 0)
+
+    def test_validate_uses_processed_count(self) -> None:
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = main(["--repo-root", str(FIXTURES), "validate", "--all"])
+        self.assertEqual(code, 0)
+        doc = json.loads(buf.getvalue())
+        self.assertIn("processed_count", doc)
+        self.assertNotIn("ok_count", doc)
+        self.assertEqual(doc["processed_count"], doc["source_count"])
+        self.assertIn("warning_code_counts", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tldr_derive/__init__.py
+++ b/tools/tldr_derive/__init__.py
@@ -1,0 +1,6 @@
+"""Offline TLDR Markdown derivation toolkit (stdlib only)."""
+
+SCHEMA_VERSION = "1.0.0"
+GENERATOR_VERSION = "0.1.1"
+
+__all__ = ["SCHEMA_VERSION", "GENERATOR_VERSION"]

--- a/tools/tldr_derive/__main__.py
+++ b/tools/tldr_derive/__main__.py
@@ -1,0 +1,6 @@
+"""Module entrypoint: python3 -m tools.tldr_derive"""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tldr_derive/cli.py
+++ b/tools/tldr_derive/cli.py
@@ -1,0 +1,312 @@
+"""Command-line interface for tools.tldr_derive."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .discovery import (
+    discover_sources,
+    resolve_source,
+)
+from .models import dumps_canonical
+from .parser import parse_source
+from .validation import validate_sources
+from .writer import (
+    OutputContainmentError,
+    build_manifest_entries,
+    filter_changed,
+    validate_output_root,
+    write_issue,
+    write_manifest,
+)
+
+
+def _repo_root_from_args(args: argparse.Namespace) -> Path:
+    return Path(args.repo_root).resolve()
+
+
+def _output_root_from_args(args: argparse.Namespace, repo_root: Path) -> Path:
+    return validate_output_root(repo_root, Path(args.output))
+
+
+def cmd_inspect(args: argparse.Namespace) -> int:
+    root = _repo_root_from_args(args)
+    sources = discover_sources(root)
+    sectors: dict[str, int] = {}
+    for source in sources:
+        sectors[source.sector] = sectors.get(source.sector, 0) + 1
+    doc = {
+        "repo_root": str(root),
+        "issue_count": len(sources),
+        "sectors": [
+            {"sector": k, "count": sectors[k]}
+            for k in sorted(sectors, key=lambda s: s.lower())
+        ],
+        "date_min": None,
+        "date_max": None,
+    }
+    if sources:
+        dates = sorted(s.date_iso for s in sources)
+        doc["date_min"] = dates[0]
+        doc["date_max"] = dates[-1]
+    sys.stdout.write(dumps_canonical(doc))
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    root = _repo_root_from_args(args)
+    sources = discover_sources(root)
+    if args.source:
+        sources = [resolve_source(root, args.source)]
+    report = validate_sources(root, sources=sources)
+    sys.stdout.write(dumps_canonical(report.to_dict()))
+    if report.error_count:
+        return 2
+    if report.privacy_hits and args.strict_privacy:
+        return 3
+    return 0
+
+
+def _select_sources(args: argparse.Namespace, root: Path, output_root: Path):
+    if args.source:
+        return [resolve_source(root, args.source)]
+    sources = discover_sources(root)
+    if getattr(args, "changed", False):
+        return filter_changed(sources, output_root)
+    return sources
+
+
+def cmd_generate(args: argparse.Namespace) -> int:
+    root = _repo_root_from_args(args)
+    try:
+        output_root = _output_root_from_args(args, root)
+    except OutputContainmentError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+    dry_run = bool(args.dry_run)
+    replace_all = bool(getattr(args, "all", False)) and not args.source
+    sources = _select_sources(args, root, output_root)
+
+    issues = []
+    failures = []
+    written = 0
+    skipped = 0
+
+    for source in sources:
+        try:
+            text = source.path.read_text(encoding="utf-8")
+            issue = parse_source(source, text)
+            path, _payload = write_issue(
+                output_root, source, issue, dry_run=dry_run
+            )
+            issues.append(issue)
+            written += 1
+            if args.verbose:
+                action = "dry-run" if dry_run else "wrote"
+                print(
+                    f"{action} {path} status={issue.parse_status} "
+                    f"family={issue.format_family}",
+                    file=sys.stderr,
+                )
+        except Exception as exc:  # noqa: BLE001 - isolate per-source failures
+            failures.append(
+                {
+                    "source_path": source.relative_path,
+                    "error": type(exc).__name__,
+                    "message": str(exc),
+                }
+            )
+
+    entries = build_manifest_entries(issues)
+    manifest_written = False
+    if issues:
+        if replace_all and failures:
+            # Do not replace a complete manifest with a partial --all result.
+            # Successful issue JSON files already written are preserved.
+            manifest_written = False
+        elif replace_all:
+            write_manifest(
+                output_root,
+                entries,
+                dry_run=dry_run,
+                merge_existing=False,
+            )
+            manifest_written = not dry_run
+        else:
+            # --changed / --source: merge only successful updates.
+            write_manifest(
+                output_root,
+                entries,
+                dry_run=dry_run,
+                merge_existing=True,
+            )
+            manifest_written = not dry_run
+    elif replace_all and not failures and not dry_run:
+        # Empty successful --all still writes an empty manifest.
+        write_manifest(
+            output_root,
+            [],
+            dry_run=False,
+            merge_existing=False,
+        )
+        manifest_written = True
+
+    summary = {
+        "dry_run": dry_run,
+        "selected": len(sources),
+        "written": written,
+        "skipped": skipped,
+        "failures": failures,
+        "manifest_written": manifest_written,
+        "manifest_replaced": bool(replace_all and manifest_written and not failures),
+        "output": str(output_root),
+    }
+    sys.stdout.write(dumps_canonical(summary))
+    return 1 if failures else 0
+
+
+def cmd_estimate(args: argparse.Namespace) -> int:
+    root = _repo_root_from_args(args)
+    sources = discover_sources(root)
+    if args.source:
+        sources = [resolve_source(root, args.source)]
+
+    sizes: list[int] = []
+    status_counts: dict[str, int] = {}
+    family_counts: dict[str, int] = {}
+
+    for source in sources:
+        text = source.path.read_text(encoding="utf-8")
+        issue = parse_source(source, text)
+        payload = issue.to_dict()
+        encoded = dumps_canonical(payload).encode("utf-8")
+        sizes.append(len(encoded))
+        status_counts[issue.parse_status] = status_counts.get(issue.parse_status, 0) + 1
+        family_counts[issue.format_family] = (
+            family_counts.get(issue.format_family, 0) + 1
+        )
+
+    sizes_sorted = sorted(sizes)
+    total = sum(sizes)
+    count = len(sizes)
+    avg = (total / count) if count else 0.0
+    median = float(statistics.median(sizes_sorted)) if sizes_sorted else 0.0
+    if sizes_sorted:
+        p95_index = min(len(sizes_sorted) - 1, int(len(sizes_sorted) * 0.95))
+        p95 = float(sizes_sorted[p95_index])
+        maximum = float(sizes_sorted[-1])
+    else:
+        p95 = 0.0
+        maximum = 0.0
+
+    manifest_size = 80 + count * 260
+    recent = [s for s in sources if s.date_iso >= "2025-07-17"]
+    if not recent:
+        recent = sources[-min(365, count) :] if count else []
+    if count and recent:
+        recent_bytes = int(avg * len(recent))
+    elif count:
+        recent_bytes = int(avg * min(365, count))
+    else:
+        recent_bytes = 0
+
+    doc = {
+        "issue_count": count,
+        "estimated_total_json_bytes": total,
+        "average_bytes_per_issue": avg,
+        "median_bytes_per_issue": median,
+        "p95_bytes_per_issue": p95,
+        "max_bytes_per_issue": maximum,
+        "estimated_manifest_size_bytes": manifest_size,
+        "estimated_annual_repository_growth_bytes": recent_bytes + int(
+            (manifest_size / max(count, 1)) * len(recent)
+        ),
+        "parse_status_counts": dict(sorted(status_counts.items())),
+        "format_family_counts": dict(sorted(family_counts.items())),
+    }
+    sys.stdout.write(dumps_canonical(doc))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m tools.tldr_derive",
+        description="Derive normalized TLDR issue JSON from local Markdown sources.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root containing TLDR* directories (default: .)",
+    )
+    parser.add_argument(
+        "--output",
+        default="generated",
+        help="Output directory for derived artifacts (default: generated)",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_inspect = sub.add_parser("inspect", help="Summarize discoverable sources")
+    p_inspect.set_defaults(func=cmd_inspect)
+
+    p_validate = sub.add_parser(
+        "validate",
+        help=(
+            "Parse all/selected sources without writing. "
+            "processed_count means parsed without exception, not parse_status=complete."
+        ),
+    )
+    p_validate.add_argument("--all", action="store_true", help="Validate all sources")
+    p_validate.add_argument("--source", help="Validate a single source path")
+    p_validate.add_argument(
+        "--strict-privacy",
+        action="store_true",
+        help="Exit non-zero if privacy hints are found in derived structures",
+    )
+    p_validate.set_defaults(func=cmd_validate)
+
+    p_gen = sub.add_parser("generate", help="Generate derived JSON artifacts")
+    mode = p_gen.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--all", action="store_true", help="Generate all sources")
+    mode.add_argument(
+        "--changed",
+        action="store_true",
+        help=(
+            "Generate sources whose hash changed, derived JSON is missing, "
+            "or schema/generator version differs"
+        ),
+    )
+    mode.add_argument("--source", help="Generate a single source path")
+    p_gen.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute outputs without writing files",
+    )
+    p_gen.add_argument(
+        "--output",
+        dest="output",
+        default=argparse.SUPPRESS,
+        help="Output directory (overrides top-level --output)",
+    )
+    p_gen.set_defaults(func=cmd_generate)
+
+    p_est = sub.add_parser("estimate", help="Estimate derived output sizes")
+    p_est.add_argument("--all", action="store_true", help="Estimate all sources")
+    p_est.add_argument("--source", help="Estimate a single source path")
+    p_est.set_defaults(func=cmd_estimate)
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command in {"validate", "estimate"} and not args.source:
+        args.all = True
+    return int(args.func(args))

--- a/tools/tldr_derive/discovery.py
+++ b/tools/tldr_derive/discovery.py
@@ -1,0 +1,141 @@
+"""Discover TLDR newsletter Markdown sources on disk."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+FILENAME_RE = re.compile(r"^article_(\d{2})-(\d{2})-(\d{4})\.md$")
+
+
+@dataclass(frozen=True)
+class SourceIssue:
+    path: Path
+    relative_path: str
+    sector: str
+    sector_slug: str
+    date_iso: str
+    date_original: str
+    content_hash: str
+    size_bytes: int
+
+
+class SourceContainmentError(ValueError):
+    """Raised when a source path escapes the repository root."""
+
+
+def is_tldr_sector_dir(name: str) -> bool:
+    return name == "TLDR" or name.startswith("TLDR ")
+
+
+def sector_slug(sector: str) -> str:
+    slug = sector.strip().lower().replace(" ", "-")
+    slug = re.sub(r"[^a-z0-9\-]+", "", slug)
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug or "unknown"
+
+
+def parse_filename_date(filename: str) -> Optional[tuple[str, str]]:
+    """Return (ISO YYYY-MM-DD, original DD-MM-YYYY) or None."""
+    match = FILENAME_RE.match(filename)
+    if not match:
+        return None
+    day, month, year = match.groups()
+    original = f"{day}-{month}-{year}"
+    try:
+        parsed = date(int(year), int(month), int(day))
+    except ValueError:
+        return None
+    return parsed.isoformat(), original
+
+
+def content_sha256(data: bytes) -> str:
+    digest = hashlib.sha256(data).hexdigest()
+    return f"sha256:{digest}"
+
+
+def ensure_path_within_root(repo_root: Path, candidate: Path) -> Path:
+    """Resolve candidate and require it to be inside repo_root via relative_to."""
+    root = repo_root.resolve()
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise SourceContainmentError(
+            f"source path escapes repository root: {candidate}"
+        ) from exc
+    return resolved
+
+
+def _source_from_resolved(root: Path, resolved: Path) -> SourceIssue:
+    try:
+        rel = resolved.relative_to(root)
+    except ValueError as exc:
+        raise SourceContainmentError(
+            f"source path escapes repository root: {resolved}"
+        ) from exc
+    # Enforce the same direct top-level sector structure as discover_sources:
+    # <sector>/<article_DD-MM-YYYY.md>
+    if len(rel.parts) != 2:
+        raise ValueError(
+            f"source must be directly under a top-level TLDR sector directory: {rel}"
+        )
+    sector = rel.parts[0]
+    if not is_tldr_sector_dir(sector):
+        raise ValueError(f"source is not under an approved TLDR sector: {rel}")
+    parsed = parse_filename_date(rel.parts[1])
+    if parsed is None:
+        raise ValueError(f"filename does not match article_DD-MM-YYYY.md: {rel}")
+    if not resolved.is_file():
+        raise FileNotFoundError(f"source not found: {rel}")
+    date_iso, date_original = parsed
+    raw = resolved.read_bytes()
+    return SourceIssue(
+        path=resolved,
+        relative_path=str(rel).replace("\\", "/"),
+        sector=sector,
+        sector_slug=sector_slug(sector),
+        date_iso=date_iso,
+        date_original=date_original,
+        content_hash=content_sha256(raw),
+        size_bytes=len(raw),
+    )
+
+
+def discover_sources(repo_root: Path) -> list[SourceIssue]:
+    """Find all approved TLDR issue Markdown files under repo_root."""
+    root = repo_root.resolve()
+    found: list[SourceIssue] = []
+    for path in sorted(root.rglob("article_*.md")):
+        if not path.is_file():
+            continue
+        try:
+            resolved = ensure_path_within_root(root, path)
+            found.append(_source_from_resolved(root, resolved))
+        except (SourceContainmentError, ValueError, FileNotFoundError):
+            continue
+    found.sort(key=lambda s: (s.sector_slug, s.date_iso, s.relative_path))
+    return found
+
+
+def resolve_source(repo_root: Path, source: str) -> SourceIssue:
+    """Resolve a single --source path argument to a SourceIssue."""
+    root = repo_root.resolve()
+    candidate = Path(source)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = ensure_path_within_root(root, candidate)
+    return _source_from_resolved(root, resolved)
+
+
+def issue_id_for(source: SourceIssue) -> str:
+    return f"{source.sector_slug}:{source.date_iso}"
+
+
+def derived_issue_relpath(source: SourceIssue) -> str:
+    year = source.date_iso[:4]
+    return f"issues/{source.sector_slug}/{year}/{source.date_iso}.json"

--- a/tools/tldr_derive/models.py
+++ b/tools/tldr_derive/models.py
@@ -1,0 +1,123 @@
+"""Data models and serialization helpers for derived TLDR issues.
+
+Ordering convention
+-------------------
+``sections[].order`` and ``articles[].order`` are **1-based** integers.
+The first section and first article in document order both receive ``order: 1``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from . import GENERATOR_VERSION, SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class WarningRecord:
+    code: str
+    message: str
+    line: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "line": self.line,
+        }
+
+
+@dataclass
+class Article:
+    id: str
+    order: int
+    title: str
+    summary: str
+    url: Optional[str]
+    reading_time_minutes: Optional[int]
+    source_domain: Optional[str]
+    content_type: str
+    is_sponsor: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "order": self.order,
+            "title": self.title,
+            "summary": self.summary,
+            "url": self.url,
+            "reading_time_minutes": self.reading_time_minutes,
+            "source_domain": self.source_domain,
+            "content_type": self.content_type,
+            "is_sponsor": self.is_sponsor,
+        }
+
+
+@dataclass
+class Section:
+    id: str
+    heading: str
+    order: int
+    articles: list[Article] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "heading": self.heading,
+            "order": self.order,
+            "articles": [a.to_dict() for a in self.articles],
+        }
+
+
+@dataclass
+class IssueDocument:
+    issue_id: str
+    sector: str
+    sector_slug: str
+    date: str
+    source_path: str
+    source_content_hash: str
+    format_family: str
+    parse_status: str
+    parse_warnings: list[WarningRecord]
+    title: str
+    sections: list[Section]
+    schema_version: str = SCHEMA_VERSION
+    generator_version: str = GENERATOR_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generator_version": self.generator_version,
+            "issue_id": self.issue_id,
+            "sector": self.sector,
+            "sector_slug": self.sector_slug,
+            "date": self.date,
+            "source_path": self.source_path,
+            "source_content_hash": self.source_content_hash,
+            "format_family": self.format_family,
+            "parse_status": self.parse_status,
+            "parse_warnings": [w.to_dict() for w in self.parse_warnings],
+            "title": self.title,
+            "sections": [s.to_dict() for s in self.sections],
+        }
+
+
+def dumps_canonical(obj: Any) -> str:
+    """Serialize to deterministic UTF-8 JSON with a trailing newline."""
+    return (
+        json.dumps(
+            obj,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=False,
+            separators=(",", ": "),
+        )
+        + "\n"
+    )
+
+
+def issue_to_canonical_json(issue: IssueDocument) -> str:
+    return dumps_canonical(issue.to_dict())

--- a/tools/tldr_derive/parser.py
+++ b/tools/tldr_derive/parser.py
@@ -1,0 +1,132 @@
+"""Orchestrate format detection and parsing into IssueDocument."""
+
+from __future__ import annotations
+
+from .discovery import SourceIssue, issue_id_for
+from .models import IssueDocument, WarningRecord
+from .parser_common import clean_text, detect_format_family, extract_issue_title
+from .parser_inline import parse_inline_url
+from .parser_references import parse_links_block
+
+
+_MATERIAL_WARNING_CODES = {
+    "dangling_reference",
+    "missing_reference_number",
+    "missing_inline_url",
+    "missing_links_block",
+    "unknown_format",
+    "empty_body",
+}
+
+
+def _count_editorial_articles(sections) -> int:
+    return sum(
+        1
+        for section in sections
+        for article in section.articles
+        if not article.is_sponsor
+    )
+
+
+def _count_all_articles(sections) -> int:
+    return sum(len(section.articles) for section in sections)
+
+
+def _sort_warnings(warnings: list[WarningRecord]) -> list[WarningRecord]:
+    return sorted(
+        warnings,
+        key=lambda w: (
+            w.code,
+            w.line if w.line is not None else -1,
+            w.message,
+        ),
+    )
+
+
+def decide_status(
+    sections,
+    warnings: list[WarningRecord],
+    text: str,
+) -> str:
+    article_count = _count_all_articles(sections)
+    body = text.strip()
+    lines = [ln for ln in body.splitlines() if ln.strip()]
+    header_only = len(lines) <= 2 and (not lines or lines[0].startswith("#"))
+
+    if article_count == 0:
+        return "failed"
+
+    material = [w for w in warnings if w.code in _MATERIAL_WARNING_CODES]
+    # Unresolved editorial URLs are material.
+    unresolved_editorial = any(
+        (article.url is None and not article.is_sponsor)
+        for section in sections
+        for article in section.articles
+    )
+    if material or unresolved_editorial:
+        return "partial"
+    if header_only:
+        return "failed"
+    return "complete"
+
+
+def parse_source(source: SourceIssue, raw_text: str) -> IssueDocument:
+    text = clean_text(raw_text)
+    issue_id = issue_id_for(source)
+    format_family = detect_format_family(text)
+    warnings: list[WarningRecord] = []
+
+    if format_family == "links_block":
+        sections, parse_warnings = parse_links_block(text, issue_id)
+        warnings.extend(parse_warnings)
+    elif format_family == "inline_url":
+        sections, parse_warnings = parse_inline_url(text, issue_id)
+        warnings.extend(parse_warnings)
+    else:
+        warnings.append(
+            WarningRecord(
+                code="unknown_format",
+                message="Could not detect links_block or inline_url format",
+                line=None,
+            )
+        )
+        # Best-effort: try links_block then inline.
+        sections, w1 = parse_links_block(text, issue_id)
+        if _count_all_articles(sections) == 0:
+            sections, w2 = parse_inline_url(text, issue_id)
+            warnings.extend(w2)
+        else:
+            warnings.extend(w1)
+
+    if not text.strip():
+        warnings.append(
+            WarningRecord(code="empty_body", message="Source file is empty", line=None)
+        )
+
+    warnings = _sort_warnings(warnings)
+    status = decide_status(sections, warnings, text)
+    title = extract_issue_title(source.sector, source.date_iso, text)
+
+    # Stable section/article ordering already assigned 1-based during parse.
+    # Ensure section ids unique by suffixing duplicates.
+    seen: dict[str, int] = {}
+    for section in sections:
+        base = section.id
+        count = seen.get(base, 0)
+        seen[base] = count + 1
+        if count:
+            section.id = f"{base}-{count + 1}"
+
+    return IssueDocument(
+        issue_id=issue_id,
+        sector=source.sector,
+        sector_slug=source.sector_slug,
+        date=source.date_iso,
+        source_path=source.relative_path,
+        source_content_hash=source.content_hash,
+        format_family=format_family,
+        parse_status=status,
+        parse_warnings=warnings,
+        title=title,
+        sections=sections,
+    )

--- a/tools/tldr_derive/parser_common.py
+++ b/tools/tldr_derive/parser_common.py
@@ -1,0 +1,201 @@
+"""Shared parsing helpers for TLDR plaintext newsletters."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from .sanitizer import decode_entities, strip_zero_width
+
+SECTION_ALLOWLIST = {
+    "BIG TECH & STARTUPS",
+    "SCIENCE & FUTURISTIC TECHNOLOGY",
+    "HEADLINES & LAUNCHES",
+    "NEWS & TRENDS",
+    "MARKETS & BUSINESS",
+    "INNOVATION & LAUNCHES",
+    "GUIDES & TUTORIALS",
+    "RESEARCH & INNOVATION",
+    "ENGINEERING & RESOURCES",
+    "ATTACKS & VULNERABILITIES",
+    "HEADLINES & TRENDS",
+    "TOOLS & RESOURCES",
+    "DEEP DIVES & ANALYSIS",
+    "ENGINEERING & RESEARCH",
+    "LAUNCHES & TOOLS",
+    "STRATEGIES & TACTICS",
+    "RESOURCES & TOOLS",
+    "OPINIONS & TUTORIALS",
+    "ARTICLES & TUTORIALS",
+    "OPINIONS & ADVICE",
+    "PROGRAMMING, DESIGN & DATA SCIENCE",
+    "QUICK LINKS",
+    "MISCELLANEOUS",
+    "FEATURES & DESIGNS",
+    "ADS & MISCELLANEOUS",
+}
+
+_SECTION_RE = re.compile(r"^[A-Z0-9][A-Z0-9 &,/'\-]{2,100}$")
+_EMOJI_LINE_RE = re.compile(
+    r"^[\U0001F300-\U0001FAFF\U00002700-\U000027BF\u2600-\u26FF\uFE0F\u200D\s]+$"
+)
+
+READING_TIME_RE = re.compile(
+    r"\((\d+)\s*MINUTE(?:S)?\s+READ\)",
+    re.IGNORECASE,
+)
+
+CONTENT_MARKER_RE = re.compile(
+    r"\((SPONSOR|GITHUB\s+REPO|GITHUB\s+REPOSITORY|COURSE|TOOL|PRODUCT\s+HUNT|"
+    r"WEBSITE|APP|REPO)\)",
+    re.IGNORECASE,
+)
+
+H1_RE = re.compile(r"^#\s+Articles\s+(.+?)\s+(\d{2}-\d{2}-\d{4})\s*$")
+
+
+def clean_text(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = strip_zero_width(text)
+    text = decode_entities(text)
+    return text
+
+
+def slugify_heading(heading: str) -> str:
+    slug = heading.strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-") or "section"
+
+
+def classify_content(title: str) -> tuple[str, bool]:
+    """Return (content_type, is_sponsor)."""
+    upper = title.upper()
+    is_sponsor = "(SPONSOR)" in upper
+    if is_sponsor:
+        return "sponsor", True
+    if "GITHUB REPO" in upper or "GITHUB REPOSITORY" in upper:
+        return "github_repo", False
+    if "(COURSE)" in upper:
+        return "course", False
+    if "(TOOL)" in upper or "(APP)" in upper or "(WEBSITE)" in upper:
+        return "tool", False
+    return "editorial", False
+
+
+def strip_markers_from_title(title: str) -> str:
+    title = READING_TIME_RE.sub("", title)
+    title = CONTENT_MARKER_RE.sub("", title)
+    title = re.sub(r"\s+", " ", title).strip(" -:\t")
+    return title
+
+
+def extract_reading_time(title: str) -> Optional[int]:
+    match = READING_TIME_RE.search(title)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def is_emoji_only_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    return bool(_EMOJI_LINE_RE.match(stripped))
+
+
+def is_section_heading(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped or is_emoji_only_line(stripped):
+        return False
+    # Drop leading emoji clusters then re-check.
+    without_emoji = re.sub(
+        r"^[\U0001F300-\U0001FAFF\U00002700-\U000027BF\u2600-\u26FF\uFE0F\u200D\s]+",
+        "",
+        stripped,
+    ).strip()
+    candidate = without_emoji or stripped
+    if candidate in SECTION_ALLOWLIST:
+        return True
+    if candidate.upper() != candidate:
+        return False
+    if not _SECTION_RE.match(candidate):
+        return False
+    if len(candidate) > 48:
+        return False
+    if not re.search(r"[A-Z]", candidate):
+        return False
+    if candidate in {"TLDR", "SIGN UP", "ADVERTISE", "VIEW ONLINE", "JOBS", "HIRE"}:
+        return False
+    if candidate.startswith("TLDR"):
+        return False
+    # Heuristic sections are narrowly shaped like "FOO & BAR" to avoid treating
+    # wrapped ALL-CAPS article titles as headings.
+    if "&" in candidate:
+        return True
+    return False
+
+
+def normalize_section_heading(line: str) -> str:
+    stripped = line.strip()
+    without_emoji = re.sub(
+        r"^[\U0001F300-\U0001FAFF\U00002700-\U000027BF\u2600-\u26FF\uFE0F\u200D\s]+",
+        "",
+        stripped,
+    ).strip()
+    return without_emoji or stripped
+
+
+def detect_format_family(text: str) -> str:
+    if re.search(r"(?m)^Links:\s*$", text) and re.search(
+        r"(?m)^\[\d+\]\s+https?://", text
+    ):
+        return "links_block"
+    if re.search(r"(?m)^\[https?://", text) or re.search(
+        r"MINUTE READ\)\s*\n\s*\[https?://", text, re.IGNORECASE
+    ):
+        return "inline_url"
+    if re.search(r"MINUTE READ\)\s*\[\d+\]", text, re.IGNORECASE):
+        return "links_block"
+    return "unknown"
+
+
+def extract_issue_title(sector: str, date_iso: str, text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # Prefer body date line like "TLDR AI 2026-07-16"
+        m = re.match(
+            rf"^TLDR(?:\s+.+?)?\s+{re.escape(date_iso)}\s*$",
+            stripped,
+            re.IGNORECASE,
+        )
+        if m:
+            return stripped
+        m2 = re.match(r"^DAILY(?:\s+\w+)?\s+UPDATE\s+(\d{4}-\d{2}-\d{2})\s*$", stripped)
+        if m2:
+            return f"{sector} {m2.group(1)}"
+    # Fallback from H1
+    for line in text.splitlines()[:5]:
+        m = H1_RE.match(line.strip())
+        if m:
+            return f"Articles {m.group(1)} {m.group(2)}"
+    return f"{sector} {date_iso}"
+
+
+def skip_preamble(lines: list[str]) -> int:
+    """Return index where editorial body likely begins (first section or article)."""
+    for i, line in enumerate(lines):
+        if is_section_heading(line):
+            return i
+        if is_emoji_only_line(line):
+            # next non-empty may be section
+            continue
+        upper = line.strip().upper()
+        if "MINUTE READ" in upper or "(SPONSOR)" in upper or "(GITHUB" in upper:
+            return i
+    # Fall back: after Sign Up / TLDR brand block
+    for i, line in enumerate(lines):
+        if re.match(r"^TLDR(?:\s|$)", line.strip(), re.IGNORECASE):
+            return min(i + 1, len(lines))
+    return 0

--- a/tools/tldr_derive/parser_inline.py
+++ b/tools/tldr_derive/parser_inline.py
@@ -1,0 +1,256 @@
+"""Parser for historical TLDR issues with inline [https://...] links."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from .models import Article, Section, WarningRecord
+from .parser_common import (
+    classify_content,
+    extract_reading_time,
+    is_emoji_only_line,
+    is_section_heading,
+    normalize_section_heading,
+    skip_preamble,
+    slugify_heading,
+    strip_markers_from_title,
+)
+from .sanitizer import normalize_public_url, source_domain_from_url, truncate_footer
+
+_INLINE_URL_RE = re.compile(r"^\[(https?://.+)\]\s*$")
+_TITLE_HINT_RE = re.compile(
+    r"(MINUTE\s+READ|\(SPONSOR\)|\(GITHUB|\(COURSE\)|\(TOOL\)|\(APP\)|\(WEBSITE\))",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_title_start(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if is_section_heading(stripped) or is_emoji_only_line(stripped):
+        return False
+    if stripped.startswith("#") or stripped.startswith("["):
+        return False
+    if stripped.lower().startswith("sign up"):
+        return False
+    if re.match(r"^TLDR\b", stripped, re.IGNORECASE):
+        return False
+    if re.match(r"^DAILY\b", stripped, re.IGNORECASE):
+        return False
+    if _TITLE_HINT_RE.search(stripped):
+        return True
+    letters = re.sub(r"[^A-Za-z]", "", stripped)
+    if letters and letters.upper() == letters and len(stripped) >= 12:
+        return True
+    return False
+
+
+def _consume_inline_url(lines: list[str], start: int) -> tuple[Optional[str], int]:
+    """Read a possibly wrapped [https://...] URL starting at start."""
+    if start >= len(lines):
+        return None, start
+    stripped = lines[start].strip()
+    if not stripped.startswith("[http"):
+        return None, start
+    parts = [stripped]
+    j = start + 1
+    while j < len(lines) and "]" not in parts[-1]:
+        nxt = lines[j].strip()
+        if not nxt:
+            break
+        parts.append(nxt)
+        j += 1
+        if "]" in nxt:
+            break
+        if j - start > 8:
+            break
+    joined = "".join(p.strip() for p in parts)
+    match = re.match(r"^\[(https?://.+)\]\s*$", joined)
+    if not match:
+        # Soft-fail: still try to extract URL-looking content.
+        inner = joined.strip("[]")
+        if inner.startswith("http"):
+            return inner, j
+        return None, start + 1
+    return match.group(1), j
+
+
+def parse_inline_url(
+    text: str,
+    issue_id: str,
+) -> tuple[list[Section], list[WarningRecord]]:
+    warnings: list[WarningRecord] = []
+    body, footer_removed = truncate_footer(text)
+    if footer_removed:
+        warnings.append(
+            WarningRecord(
+                code="footer_truncated",
+                message="Subscription/account footer truncated before parse",
+                line=None,
+            )
+        )
+
+    lines = body.splitlines()
+    start = skip_preamble(lines)
+    lines = lines[start:]
+    line_offset = start
+
+    sections: list[Section] = []
+    current_heading = "GENERAL"
+    pending: list[dict[str, Any]] = []
+    section_order = 0
+
+    def flush_section() -> None:
+        nonlocal section_order, pending, current_heading
+        if not pending and current_heading == "GENERAL" and not sections:
+            return
+        section_order += 1
+        articles = [
+            Article(
+                id=raw["id"],
+                order=idx,
+                title=raw["title"],
+                summary=raw["summary"],
+                url=raw["url"],
+                reading_time_minutes=raw["reading_time_minutes"],
+                source_domain=raw["source_domain"],
+                content_type=raw["content_type"],
+                is_sponsor=raw["is_sponsor"],
+            )
+            for idx, raw in enumerate(pending, start=1)
+        ]
+        sections.append(
+            Section(
+                id=slugify_heading(current_heading),
+                heading=current_heading,
+                order=section_order,
+                articles=articles,
+            )
+        )
+        pending = []
+
+    i = 0
+    article_seq = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if not stripped:
+            i += 1
+            continue
+        if is_emoji_only_line(stripped):
+            i += 1
+            continue
+        if is_section_heading(stripped):
+            flush_section()
+            current_heading = normalize_section_heading(stripped)
+            i += 1
+            continue
+
+        if not _looks_like_title_start(stripped):
+            i += 1
+            continue
+
+        title_parts = [stripped]
+        j = i + 1
+        while j < len(lines):
+            nxt = lines[j].strip()
+            if not nxt:
+                break
+            if nxt.startswith("[http"):
+                break
+            if is_section_heading(nxt) or is_emoji_only_line(nxt):
+                break
+            if _looks_like_title_start(nxt) and _TITLE_HINT_RE.search(nxt):
+                break
+            # Continue title wrap until marker complete or URL.
+            if _TITLE_HINT_RE.search(" ".join(title_parts)) and not _TITLE_HINT_RE.search(
+                nxt
+            ):
+                # Likely finished title markers; stop unless clearly continuation.
+                if nxt.isupper() or len(nxt) < 40:
+                    title_parts.append(nxt)
+                    j += 1
+                    continue
+                break
+            title_parts.append(nxt)
+            j += 1
+            if j - i > 6:
+                break
+
+        title_joined = " ".join(title_parts)
+        reading_time = extract_reading_time(title_joined)
+        content_type, is_sponsor = classify_content(title_joined)
+        title = strip_markers_from_title(title_joined)
+
+        url_raw, after_url = _consume_inline_url(lines, j)
+        src_line = line_offset + i + 1
+
+        # Require a recognizable article marker for inline-era titles.
+        if not _TITLE_HINT_RE.search(title_joined):
+            i = j
+            continue
+
+        url = normalize_public_url(url_raw) if url_raw else None
+        if url_raw and url is None:
+            warnings.append(
+                WarningRecord(
+                    code="skipped_private_or_invalid_url",
+                    message="Inline URL omitted after privacy/validity sanitization",
+                    line=src_line,
+                )
+            )
+            i = after_url
+            continue
+        if url_raw is None:
+            warnings.append(
+                WarningRecord(
+                    code="missing_inline_url",
+                    message=f"Article '{title}' has no inline URL",
+                    line=src_line,
+                )
+            )
+
+        k = after_url if url_raw is not None else j
+        if k < len(lines) and not lines[k].strip():
+            k += 1
+
+        summary_parts: list[str] = []
+        while k < len(lines):
+            nxt = lines[k].strip()
+            if not nxt:
+                break
+            if is_section_heading(nxt) or is_emoji_only_line(nxt):
+                break
+            if nxt.startswith("[http"):
+                break
+            if _looks_like_title_start(nxt):
+                break
+            summary_parts.append(nxt)
+            k += 1
+
+        article_seq += 1
+        pending.append(
+            {
+                "id": f"{issue_id}:o{article_seq:03d}",
+                "title": title,
+                "summary": " ".join(summary_parts).strip(),
+                "url": url,
+                "reading_time_minutes": reading_time,
+                "source_domain": source_domain_from_url(url),
+                "content_type": content_type,
+                "is_sponsor": is_sponsor,
+            }
+        )
+        i = k
+
+    flush_section()
+
+    if len(sections) > 1:
+        sections = [
+            s for s in sections if not (s.heading == "GENERAL" and not s.articles)
+        ]
+        for idx, section in enumerate(sections, start=1):
+            section.order = idx
+
+    return sections, warnings

--- a/tools/tldr_derive/parser_references.py
+++ b/tools/tldr_derive/parser_references.py
@@ -1,0 +1,291 @@
+"""Parser for modern TLDR issues that use a numbered Links: block."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from .models import Article, Section, WarningRecord
+from .parser_common import (
+    classify_content,
+    extract_reading_time,
+    is_emoji_only_line,
+    is_section_heading,
+    normalize_section_heading,
+    skip_preamble,
+    slugify_heading,
+    strip_markers_from_title,
+)
+from .sanitizer import normalize_public_url, source_domain_from_url, truncate_footer
+
+_REF_AT_END_RE = re.compile(r"\[(\d+)\]\s*$")
+_LINK_DEF_RE = re.compile(r"^\[(\d+)\]\s+(\S+)\s*$")
+_TITLE_HINT_RE = re.compile(
+    r"(MINUTE\s+READ|\(SPONSOR\)|\(GITHUB|\(COURSE\)|\(TOOL\)|\(APP\)|\(WEBSITE\))",
+    re.IGNORECASE,
+)
+
+
+def parse_link_definitions(links_text: str) -> dict[int, str]:
+    defs: dict[int, str] = {}
+    pending_num: Optional[int] = None
+    pending_parts: list[str] = []
+    for line in links_text.splitlines():
+        stripped = line.strip()
+        if not stripped or set(stripped) <= {"-"}:
+            continue
+        match = _LINK_DEF_RE.match(stripped)
+        if match:
+            if pending_num is not None and pending_parts:
+                defs[pending_num] = "".join(pending_parts)
+            pending_num = int(match.group(1))
+            pending_parts = [match.group(2)]
+            continue
+        if pending_num is not None:
+            pending_parts.append(stripped)
+    if pending_num is not None and pending_parts:
+        defs[pending_num] = "".join(pending_parts)
+    return defs
+
+
+def _looks_like_title_start(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if is_section_heading(stripped) or is_emoji_only_line(stripped):
+        return False
+    if stripped.startswith("#"):
+        return False
+    lower = stripped.lower()
+    if lower.startswith("sign up"):
+        return False
+    if lower.startswith("advertise"):
+        return False
+    if lower.startswith("view online"):
+        return False
+    if lower.startswith("together with"):
+        # Sponsor intro line; allow as title start only with markers later.
+        pass
+    if re.match(r"^TLDR\b", stripped, re.IGNORECASE):
+        return False
+    if re.match(r"^DAILY\b", stripped, re.IGNORECASE):
+        return False
+    if _REF_AT_END_RE.search(stripped):
+        return True
+    if _TITLE_HINT_RE.search(stripped):
+        return True
+    letters = re.sub(r"[^A-Za-z]", "", stripped)
+    if letters and letters.upper() == letters and len(stripped) >= 12:
+        return True
+    return False
+
+
+def parse_links_block(
+    text: str,
+    issue_id: str,
+) -> tuple[list[Section], list[WarningRecord]]:
+    warnings: list[WarningRecord] = []
+
+    if "Links:" in text:
+        body, _, links = text.partition("Links:")
+        link_defs = parse_link_definitions(links)
+    else:
+        body = text
+        link_defs = {}
+        warnings.append(
+            WarningRecord(
+                code="missing_links_block",
+                message="Expected Links: block for links_block format",
+                line=None,
+            )
+        )
+
+    body, footer_removed = truncate_footer(body)
+    if footer_removed:
+        warnings.append(
+            WarningRecord(
+                code="footer_truncated",
+                message="Subscription/account footer truncated before parse",
+                line=None,
+            )
+        )
+
+    lines = body.splitlines()
+    start = skip_preamble(lines)
+    lines = lines[start:]
+    line_offset = start
+
+    sections: list[Section] = []
+    current_heading = "GENERAL"
+    pending: list[dict[str, Any]] = []
+    section_order = 0
+
+    def flush_section() -> None:
+        nonlocal section_order, pending, current_heading
+        if not pending and current_heading == "GENERAL" and not sections:
+            return
+        section_order += 1
+        articles: list[Article] = []
+        for idx, raw in enumerate(pending, start=1):
+            articles.append(
+                Article(
+                    id=raw["id"],
+                    order=idx,
+                    title=raw["title"],
+                    summary=raw["summary"],
+                    url=raw["url"],
+                    reading_time_minutes=raw["reading_time_minutes"],
+                    source_domain=raw["source_domain"],
+                    content_type=raw["content_type"],
+                    is_sponsor=raw["is_sponsor"],
+                )
+            )
+        sections.append(
+            Section(
+                id=slugify_heading(current_heading),
+                heading=current_heading,
+                order=section_order,
+                articles=articles,
+            )
+        )
+        pending = []
+
+    i = 0
+    article_seq = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if not stripped:
+            i += 1
+            continue
+        if is_emoji_only_line(stripped):
+            i += 1
+            continue
+        if is_section_heading(stripped):
+            flush_section()
+            current_heading = normalize_section_heading(stripped)
+            i += 1
+            continue
+
+        if not _looks_like_title_start(stripped):
+            i += 1
+            continue
+
+        title_parts = [stripped]
+        j = i + 1
+        while j < len(lines) and not _REF_AT_END_RE.search(title_parts[-1]):
+            nxt = lines[j].strip()
+            if not nxt:
+                break
+            if is_section_heading(nxt) or is_emoji_only_line(nxt):
+                break
+            # Continuation may itself look like a title start (wrapped headline).
+            title_parts.append(nxt)
+            j += 1
+            if _REF_AT_END_RE.search(nxt):
+                break
+            if j - i > 6:
+                break
+
+        title_joined = " ".join(title_parts)
+        ref_match = _REF_AT_END_RE.search(title_joined)
+        ref_num: Optional[int] = int(ref_match.group(1)) if ref_match else None
+        if ref_match:
+            title_joined = title_joined[: ref_match.start()].rstrip()
+
+        reading_time = extract_reading_time(title_joined)
+        content_type, is_sponsor = classify_content(title_joined)
+        title = strip_markers_from_title(title_joined)
+
+        summary_parts: list[str] = []
+        k = j
+        if k < len(lines) and not lines[k].strip():
+            k += 1
+        while k < len(lines):
+            nxt = lines[k].strip()
+            if not nxt:
+                break
+            if is_section_heading(nxt) or is_emoji_only_line(nxt):
+                break
+            if _looks_like_title_start(nxt):
+                break
+            summary_parts.append(nxt)
+            k += 1
+
+        summary = " ".join(summary_parts).strip()
+        article_seq += 1
+        article_id = (
+            f"{issue_id}:a{ref_num:02d}"
+            if ref_num is not None
+            else f"{issue_id}:o{article_seq:03d}"
+        )
+
+        url = None
+        domain = None
+        src_line = line_offset + i + 1
+        skip_article = False
+        if ref_num is None:
+            # Require a content marker for ref-less titles.
+            if not _TITLE_HINT_RE.search(title_joined):
+                i = k
+                continue
+            warnings.append(
+                WarningRecord(
+                    code="missing_reference_number",
+                    message=f"Article '{title}' has no reference number",
+                    line=src_line,
+                )
+            )
+        elif ref_num not in link_defs:
+            warnings.append(
+                WarningRecord(
+                    code="dangling_reference",
+                    message=f"Reference {ref_num} has no link definition",
+                    line=src_line,
+                )
+            )
+        else:
+            url = normalize_public_url(link_defs[ref_num])
+            if url is None:
+                # Private/nav/account links are omitted from editorial output.
+                warnings.append(
+                    WarningRecord(
+                        code="skipped_private_or_invalid_url",
+                        message=(
+                            f"Reference {ref_num} omitted after privacy/"
+                            "validity sanitization"
+                        ),
+                        line=src_line,
+                    )
+                )
+                skip_article = True
+            else:
+                domain = source_domain_from_url(url)
+
+        if skip_article:
+            i = k
+            continue
+
+        pending.append(
+            {
+                "id": article_id,
+                "title": title,
+                "summary": summary,
+                "url": url,
+                "reading_time_minutes": reading_time,
+                "source_domain": domain,
+                "content_type": content_type,
+                "is_sponsor": is_sponsor,
+            }
+        )
+        i = k
+
+    flush_section()
+
+    if len(sections) > 1:
+        sections = [
+            s for s in sections if not (s.heading == "GENERAL" and not s.articles)
+        ]
+        for idx, section in enumerate(sections, start=1):
+            section.order = idx
+
+    return sections, warnings

--- a/tools/tldr_derive/sanitizer.py
+++ b/tools/tldr_derive/sanitizer.py
@@ -1,0 +1,193 @@
+"""URL privacy sanitization and HTML/entity cleanup."""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+# Zero-width / BOM characters commonly injected in TLDR preheaders.
+_ZW_RE = re.compile(r"[\u200b\u200c\u200d\ufeff]")
+
+_SPARKLP_RE = re.compile(r"(^|\.)hub\.sparklp\.co$", re.IGNORECASE)
+_REFER_RE = re.compile(r"(^|\.)refer\.tldr\.tech$", re.IGNORECASE)
+_TLDR_TECH_RE = re.compile(r"(^|\.)tldr\.tech$", re.IGNORECASE)
+_TLDR_NEWSLETTER_RE = re.compile(r"(^|\.)tldrnewsletter\.com$", re.IGNORECASE)
+
+# Subscriber-identifying query keys stripped only on management/newsletter hosts.
+_SUBSCRIBER_PARAM_KEYS = {
+    "email",
+    "subscriber",
+    "subscriber_id",
+}
+
+_PRIVATE_PATH_RE = re.compile(
+    r"(^|/)(unsubscribe|manage|preferences?|account|settings|email-preferences)"
+    r"(/|$|\?)",
+    re.IGNORECASE,
+)
+
+
+def strip_zero_width(text: str) -> str:
+    return _ZW_RE.sub("", text)
+
+
+def decode_entities(text: str) -> str:
+    once = html.unescape(text)
+    twice = html.unescape(once)
+    return twice
+
+
+def repair_wrapped_url(raw: str) -> str:
+    """Join a URL that was soft-wrapped across lines or broken by spaces."""
+    cleaned = decode_entities(raw)
+    cleaned = cleaned.replace("\r", "").replace("\n", "").replace(" ", "")
+    cleaned = strip_zero_width(cleaned)
+    return cleaned.strip().rstrip(").,;]>\"'")
+
+
+def _host(netloc: str) -> str:
+    return (netloc or "").lower()
+
+
+def _is_management_host(host: str) -> bool:
+    return bool(
+        _TLDR_TECH_RE.search(host)
+        or _TLDR_NEWSLETTER_RE.search(host)
+        or _SPARKLP_RE.search(host)
+        or _REFER_RE.search(host)
+    )
+
+
+def is_private_url(url: str) -> bool:
+    """True when the URL is a subscription/account/unsubscribe/referral link."""
+    if not url:
+        return True
+    repaired = repair_wrapped_url(url)
+    parts = urlsplit(repaired)
+    host = _host(parts.netloc)
+    path = parts.path or ""
+    query = parts.query or ""
+    lowered_path_q = f"{path}?{query}".lower()
+
+    if _SPARKLP_RE.search(host) or _REFER_RE.search(host):
+        return True
+
+    if _TLDR_NEWSLETTER_RE.search(host):
+        if re.search(r"unsubscribe|/manage\b|preferences?|account", lowered_path_q):
+            return True
+        if re.search(r"(^|&)(email|subscriber|subscriber_id)=", query, re.IGNORECASE):
+            return True
+
+    if _TLDR_TECH_RE.search(host):
+        if re.search(r"/(manage|unsubscribe|preferences?|account)(/|$|\?)", path, re.I):
+            return True
+        if re.search(r"(^|&)(email|subscriber|subscriber_id)=", query, re.IGNORECASE):
+            # manage?email= and similar on tldr.tech
+            if "manage" in path.lower() or "unsubscribe" in path.lower():
+                return True
+
+    if _PRIVATE_PATH_RE.search(path) and _is_management_host(host):
+        return True
+
+    return False
+
+
+def normalize_public_url(url: Optional[str]) -> Optional[str]:
+    """Return a sanitized http(s) URL, or None if invalid/private/unresolved.
+
+    Ordinary editorial query parameters (including ``t``, ``p``, ``s``, ``token``,
+    ``uid``, ``user_id``) are preserved. Subscriber-identifying parameters are
+    stripped only on known TLDR/TLDR-newsletter management hosts; fully private
+    management/unsubscribe URLs are rejected entirely.
+    """
+    if url is None:
+        return None
+    repaired = repair_wrapped_url(url)
+    if not repaired:
+        return None
+    if is_private_url(repaired):
+        return None
+    parts = urlsplit(repaired)
+    if parts.scheme not in ("http", "https"):
+        return None
+    if not parts.netloc:
+        return None
+
+    host = _host(parts.netloc)
+    query_pairs = parse_qsl(parts.query, keep_blank_values=True)
+    if _is_management_host(host):
+        query_pairs = [
+            (k, v)
+            for k, v in query_pairs
+            if k.lower() not in _SUBSCRIBER_PARAM_KEYS
+        ]
+    # Never emit subscriber email/identity params on any host.
+    query_pairs = [
+        (k, v)
+        for k, v in query_pairs
+        if k.lower() not in _SUBSCRIBER_PARAM_KEYS
+    ]
+
+    new_query = urlencode(query_pairs, doseq=True)
+    normalized = urlunsplit(
+        (parts.scheme, parts.netloc.lower(), parts.path, new_query, "")
+    )
+    if is_private_url(normalized):
+        return None
+    return normalized
+
+
+def source_domain_from_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    host = urlsplit(url).netloc.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host or None
+
+
+_FOOTER_START_RE = re.compile(
+    r"(?im)^(?:"
+    r"if you don't want to receive|"
+    r"if you have any comments or feedback|"
+    r"thanks for reading|"
+    r"want to advertise|"
+    r"if your company is interested in reaching|"
+    r"we help cutting edge companies hire|"
+    r"click here to unsubscribe|"
+    r"manage your subscription|"
+    r"unsubscribe here|"
+    r"love tldr|"
+    r"tell your friends|"
+    r"tell friends|"
+    r"share tldr|"
+    r"if you are in a hiring position|"
+    r"if you're hiring|"
+    r"hire (ai|tech|software)|"
+    r"jobs? board|"
+    r"careers at tldr"
+    r")"
+)
+
+
+def truncate_footer(text: str) -> tuple[str, bool]:
+    """Remove trailing subscription/account footer. Returns (text, removed?)."""
+    lines = text.splitlines()
+    cut = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if _FOOTER_START_RE.match(stripped):
+            cut = i
+            break
+        lower = stripped.lower()
+        if "unsubscribe" in lower and ("http" in lower or "[" in lower):
+            cut = i
+            break
+        if re.search(r"/manage\?email=", lower):
+            cut = i
+            break
+    if cut is None:
+        return text, False
+    return "\n".join(lines[:cut]).rstrip() + "\n", True

--- a/tools/tldr_derive/validation.py
+++ b/tools/tldr_derive/validation.py
@@ -1,0 +1,119 @@
+"""Validation helpers for derived outputs and sources (read-only)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .discovery import SourceIssue, discover_sources
+from .parser import parse_source
+from .sanitizer import is_private_url
+
+
+@dataclass
+class ValidationReport:
+    """Corpus validation summary.
+
+    ``processed_count`` is the number of sources parsed without raising an
+    exception. It is **not** the count of ``parse_status == "complete"`` issues.
+    Use ``parse_status_counts`` for complete/partial/failed totals.
+    """
+
+    source_count: int = 0
+    processed_count: int = 0
+    error_count: int = 0
+    parse_status_counts: dict[str, int] = field(default_factory=dict)
+    format_family_counts: dict[str, int] = field(default_factory=dict)
+    warning_code_counts: dict[str, int] = field(default_factory=dict)
+    privacy_hits: list[str] = field(default_factory=list)
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    warnings_sample: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_count": self.source_count,
+            # processed_count: parsed without exception (not parse_status=complete).
+            "processed_count": self.processed_count,
+            "error_count": self.error_count,
+            "parse_status_counts": dict(sorted(self.parse_status_counts.items())),
+            "format_family_counts": dict(sorted(self.format_family_counts.items())),
+            "warning_code_counts": dict(sorted(self.warning_code_counts.items())),
+            "privacy_hits": self.privacy_hits,
+            "errors": self.errors,
+            "warnings_sample": self.warnings_sample,
+        }
+
+
+def _scan_issue_privacy(issue_dict: dict[str, Any], source_path: str) -> list[str]:
+    hits: list[str] = []
+    for section in issue_dict.get("sections", []):
+        for article in section.get("articles", []):
+            url = article.get("url")
+            if not url:
+                continue
+            if is_private_url(url):
+                hits.append(f"{source_path}: private url slipped through")
+                continue
+            if re.search(r"[?&](email|subscriber|subscriber_id)=", url, re.IGNORECASE):
+                hits.append(f"{source_path}: subscriber parameter in article url")
+            # Flag only TLDR management hosts with manage/unsubscribe paths.
+            if re.search(
+                r"https?://(?:[\w.-]+\.)?(?:tldr\.tech|tldrnewsletter\.com)/[^\s]*"
+                r"(?:/manage(?:/|\?)|/unsubscribe(?:/|\?)|unsubscribe\?)",
+                url,
+                re.IGNORECASE,
+            ):
+                hits.append(f"{source_path}: TLDR management url in article url")
+            if re.search(r"hub\.sparklp\.co|refer\.tldr\.tech", url, re.IGNORECASE):
+                hits.append(f"{source_path}: referral/account url in article url")
+    return hits
+
+
+def validate_sources(
+    repo_root: Path,
+    sources: Optional[list[SourceIssue]] = None,
+) -> ValidationReport:
+    """Parse all sources in memory; never writes."""
+    report = ValidationReport()
+    if sources is None:
+        sources = discover_sources(repo_root)
+    report.source_count = len(sources)
+
+    for source in sources:
+        try:
+            text = source.path.read_text(encoding="utf-8")
+            issue = parse_source(source, text)
+            report.processed_count += 1
+            report.parse_status_counts[issue.parse_status] = (
+                report.parse_status_counts.get(issue.parse_status, 0) + 1
+            )
+            report.format_family_counts[issue.format_family] = (
+                report.format_family_counts.get(issue.format_family, 0) + 1
+            )
+            for warning in issue.parse_warnings:
+                report.warning_code_counts[warning.code] = (
+                    report.warning_code_counts.get(warning.code, 0) + 1
+                )
+            issue_dict = issue.to_dict()
+            privacy = _scan_issue_privacy(issue_dict, source.relative_path)
+            report.privacy_hits.extend(privacy)
+            if issue.parse_warnings and len(report.warnings_sample) < 50:
+                report.warnings_sample.append(
+                    {
+                        "source_path": source.relative_path,
+                        "parse_status": issue.parse_status,
+                        "warnings": [w.to_dict() for w in issue.parse_warnings[:5]],
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 - isolate per-file failures
+            report.error_count += 1
+            report.errors.append(
+                {
+                    "source_path": source.relative_path,
+                    "error": type(exc).__name__,
+                    "message": str(exc),
+                }
+            )
+    return report

--- a/tools/tldr_derive/writer.py
+++ b/tools/tldr_derive/writer.py
@@ -1,0 +1,228 @@
+"""Atomic writers and output path containment for derived artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from . import GENERATOR_VERSION, SCHEMA_VERSION
+from .discovery import SourceIssue, derived_issue_relpath, is_tldr_sector_dir
+from .models import IssueDocument, dumps_canonical, issue_to_canonical_json
+
+
+class OutputContainmentError(ValueError):
+    """Raised when a write would escape the configured output directory."""
+
+
+def validate_output_root(repo_root: Path, output_root: Path) -> Path:
+    """Reject output roots inside approved TLDR source directories.
+
+    Must be called before any directory or file is created under ``output_root``.
+    """
+    root = repo_root.resolve()
+    # Resolve without requiring the path to exist yet.
+    out = output_root.expanduser()
+    if not out.is_absolute():
+        out = (Path.cwd() / out).resolve()
+    else:
+        out = out.resolve()
+
+    try:
+        rel = out.relative_to(root)
+    except ValueError:
+        # Output outside the repository is allowed.
+        return out
+
+    if rel.parts:
+        first = rel.parts[0]
+        if is_tldr_sector_dir(first):
+            raise OutputContainmentError(
+                f"refusing output root inside source newsletter directory: {out}"
+            )
+    return out
+
+
+def ensure_within(output_root: Path, target: Path) -> Path:
+    root = output_root.resolve()
+    resolved = target.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise OutputContainmentError(
+            f"refusing to write outside output root: {resolved} (root={root})"
+        ) from exc
+    return resolved
+
+
+def atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding, newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+
+def issue_output_path(output_root: Path, source: SourceIssue) -> Path:
+    rel = derived_issue_relpath(source)
+    return ensure_within(output_root, output_root / rel)
+
+
+def write_issue(
+    output_root: Path,
+    source: SourceIssue,
+    issue: IssueDocument,
+    *,
+    dry_run: bool = False,
+) -> tuple[Path, str]:
+    """Serialize and optionally write one issue. Returns (path, canonical_json)."""
+    path = issue_output_path(output_root, source)
+    payload = issue_to_canonical_json(issue)
+    if not dry_run:
+        atomic_write_text(path, payload)
+    return path, payload
+
+
+def build_manifest_entries(issues: list[IssueDocument]) -> list[dict[str, Any]]:
+    entries = []
+    for issue in issues:
+        year = issue.date[:4]
+        derived = f"issues/{issue.sector_slug}/{year}/{issue.date}.json"
+        entries.append(
+            {
+                "issue_id": issue.issue_id,
+                "sector": issue.sector,
+                "sector_slug": issue.sector_slug,
+                "date": issue.date,
+                "source_path": issue.source_path,
+                "source_content_hash": issue.source_content_hash,
+                "schema_version": issue.schema_version,
+                "generator_version": issue.generator_version,
+                "format_family": issue.format_family,
+                "parse_status": issue.parse_status,
+                "derived_path": derived,
+            }
+        )
+    entries.sort(key=lambda e: (e["sector_slug"], e["date"], e["issue_id"]))
+    return entries
+
+
+def write_manifest(
+    output_root: Path,
+    entries: list[dict[str, Any]],
+    *,
+    dry_run: bool = False,
+    merge_existing: bool = True,
+) -> tuple[Path, str]:
+    path = ensure_within(output_root, output_root / "manifest.json")
+    merged = list(entries)
+    if merge_existing and path.exists():
+        try:
+            prior = json.loads(path.read_text(encoding="utf-8"))
+            prior_entries = prior.get("issues", [])
+            by_id = {e["issue_id"]: e for e in prior_entries}
+            for entry in entries:
+                by_id[entry["issue_id"]] = entry
+            merged = sorted(
+                by_id.values(),
+                key=lambda e: (e["sector_slug"], e["date"], e["issue_id"]),
+            )
+        except (OSError, json.JSONDecodeError):
+            merged = list(entries)
+
+    doc = {
+        "schema_version": SCHEMA_VERSION,
+        "generator_version": GENERATOR_VERSION,
+        "issues": merged,
+    }
+    payload = dumps_canonical(doc)
+    if not dry_run:
+        atomic_write_text(path, payload)
+    return path, payload
+
+
+def load_manifest_entries_by_source(output_root: Path) -> dict[str, dict[str, Any]]:
+    """Map source_path -> manifest entry."""
+    path = output_root / "manifest.json"
+    if not path.exists():
+        return {}
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for entry in doc.get("issues", []):
+        src = entry.get("source_path")
+        if src:
+            result[src] = entry
+    return result
+
+
+def load_manifest_hashes(output_root: Path) -> dict[str, str]:
+    """Map source_path -> source_content_hash from existing manifest."""
+    return {
+        src: entry["source_content_hash"]
+        for src, entry in load_manifest_entries_by_source(output_root).items()
+        if entry.get("source_content_hash")
+    }
+
+
+def filter_changed(
+    sources: Iterable[SourceIssue],
+    output_root: Path,
+    *,
+    schema_version: str = SCHEMA_VERSION,
+    generator_version: str = GENERATOR_VERSION,
+    manifest_entries: Optional[dict[str, dict[str, Any]]] = None,
+) -> list[SourceIssue]:
+    """Return sources that need regeneration (hash/missing/schema/generator)."""
+    if manifest_entries is None:
+        manifest_entries = load_manifest_entries_by_source(output_root)
+
+    changed: list[SourceIssue] = []
+    for source in sources:
+        entry = manifest_entries.get(source.relative_path)
+        derived = issue_output_path(output_root, source)
+        if entry is None:
+            changed.append(source)
+            continue
+        if entry.get("source_content_hash") != source.content_hash:
+            changed.append(source)
+            continue
+        if not derived.exists():
+            changed.append(source)
+            continue
+        if entry.get("schema_version") != schema_version:
+            changed.append(source)
+            continue
+        if entry.get("generator_version") != generator_version:
+            changed.append(source)
+            continue
+    return changed
+
+
+def read_existing_issue_hash(output_root: Path, source: SourceIssue) -> Optional[str]:
+    path = issue_output_path(output_root, source)
+    if not path.exists():
+        return None
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return doc.get("source_content_hash")


### PR DESCRIPTION
## Summary

Adds an isolated, standard-library-only derivation layer for the future
TLDR newsletter web reader.

The implementation parses existing Markdown newsletters into deterministic,
schema-versioned issue documents without modifying or executing the production
IMAP pipeline.

## Scope

- Offline discovery and parsing of TLDR Markdown issues
- Support for historical inline-URL and modern reference-link formats
- Structured sections and articles
- Privacy sanitization (reject TLDR manage/unsubscribe links; preserve editorial query params)
- Deterministic and atomic JSON generation
- Incremental generation via source hashes, missing outputs, and schema/generator versions
- Offline validation and size estimation
- Safe GitHub Actions workflow (unittest + strict privacy validation only)
- 41 safe unittest cases

## Explicitly unchanged

- `script.py`
- `automation.sh`
- `push_script.sh`
- `cronjob`
- `Pipfile.lock`
- all historical newsletter Markdown files

## Verification

- 5,928 approved TLDR sources validated offline
- 5,597 complete
- 327 partial
- 4 failed
- 0 privacy hits
- source Markdown inventory hash unchanged
- production file hashes unchanged
- no full backfill committed
- no IMAP or network operation executed
- no runtime dependency added
- history squashed to a single commit before merge

## Reports

- `docs/reports/PRE_IMPLEMENTATION_REPORT.md`
- `docs/reports/POST_IMPLEMENTATION_REPORT.md`
- `docs/data-contract.md`

## Out of scope

- historical JSON backfill
- web interface
- search engine
- cron integration
- production ingestion changes