### PR TITLE
Fix inline-era titles that embed [https://...] on the same line.

### DIFF
--- a/tests_derive/expected/header_only_sample.json
+++ b/tests_derive/expected/header_only_sample.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generator_version": "0.1.1",
+  "generator_version": "0.1.2",
   "issue_id": "tldr:2023-01-17",
   "sector": "TLDR",
   "sector_slug": "tldr",

--- a/tests_derive/expected/inline_url_sample.json
+++ b/tests_derive/expected/inline_url_sample.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generator_version": "0.1.1",
+  "generator_version": "0.1.2",
   "issue_id": "tldr-ai:2023-02-16",
   "sector": "TLDR AI",
   "sector_slug": "tldr-ai",

--- a/tests_derive/expected/links_block_sample.json
+++ b/tests_derive/expected/links_block_sample.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generator_version": "0.1.1",
+  "generator_version": "0.1.2",
   "issue_id": "tldr-ai:2026-07-16",
   "sector": "TLDR AI",
   "sector_slug": "tldr-ai",

--- a/tests_derive/expected/multiline_sample.json
+++ b/tests_derive/expected/multiline_sample.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generator_version": "0.1.1",
+  "generator_version": "0.1.2",
   "issue_id": "tldr:2024-03-15",
   "sector": "TLDR",
   "sector_slug": "tldr",

--- a/tests_derive/fixtures/repo/TLDR/article_08-02-2023.md
+++ b/tests_derive/fixtures/repo/TLDR/article_08-02-2023.md
@@ -1,0 +1,55 @@
+# Articles TLDR 08-02-2023
+
+Sanitized fixture for same-line and wrapped inline URLs.
+
+Sign Up [https://tldr.tech/signup?utm_source=tldr]|Advertise
+[https://advertise.tldr.tech/?utm_source=tldr]|View
+Online
+[https://actions.tldrnewsletter.com/web-version?ep=1&lc=abc]
+
+		TLDR 
+
+DAILY UPDATE 2023-02-08
+
+🚀 
+
+BIG TECH & STARTUPS
+
+CLASSIC NEXT LINE ARTICLE (5 MINUTE READ)
+[https://www.theverge.com/2023/2/7/example-next-line?utm_source=tldrnewsletter]
+
+Summary for the classic next-line inline URL pattern. Must keep working.
+
+META ASKS MANY MANAGERS TO GET BACK TO MAKING THINGS OR LEAVE (2
+MINUTE READ) [https://archive.ph/JG1qD?utm_source=tldrnewsletter]
+
+Managers were told to return to individual contributor work or leave
+the company.
+
+SAME LINE ARCHIVE LINK (3 MINUTE READ) [https://archive.ph/tHRU8?utm_source=tldrnewsletter]
+
+A same-line archive.ph URL after the reading-time marker.
+
+WRAPPED READING TIME THEN NEXT LINE URL (11
+MINUTE READ)
+[https://www.simplethread.com/20-things-ive-learned/?utm_source=tldrnewsletter]
+
+Wrapped reading-time marker with the URL on the following line.
+
+ORDINARY DOMAIN SAME LINE (4 MINUTE READ) [https://arxiv.org/abs/2302.00001]
+
+Same-line URL on an ordinary http(s) domain, not archive.ph.
+
+QUICK LINKS
+
+SHORT NEXT LINE (1 MINUTE READ)
+[https://example.com/quick-next?utm_source=tldrnewsletter]
+
+A short quick link with next-line URL.
+
+If you don't want to receive future editions of TLDR, please click
+here to unsubscribe
+[https://actions.tldrnewsletter.com/unsubscribe?ep=1&l=secret&s=token]
+
+Thanks for reading,
+Dan

--- a/tests_derive/test_derive.py
+++ b/tests_derive/test_derive.py
@@ -53,10 +53,11 @@ class DiscoveryTests(unittest.TestCase):
         self.assertIn("TLDR AI/article_16-07-2026.md", paths)
         self.assertIn("TLDR/article_17-01-2023.md", paths)
         self.assertIn("TLDR/article_15-03-2024.md", paths)
+        self.assertIn("TLDR/article_08-02-2023.md", paths)
         self.assertIn("TLDR Crypto/article_01-01-2024.md", paths)
         self.assertTrue(all(not p.startswith("NotTLDR") for p in paths))
         self.assertTrue(all("GoDaddy" not in p for p in paths))
-        self.assertEqual(len(sources), 5)
+        self.assertEqual(len(sources), 6)
 
     def test_filename_date_extraction(self) -> None:
         self.assertEqual(
@@ -124,6 +125,72 @@ class ParserTests(unittest.TestCase):
         self.assertTrue(any("BING AI" in t for t in titles))
         urls = [a.url for s in issue.sections for a in s.articles]
         self.assertTrue(any(u and "theverge.com" in u for u in urls))
+
+    def test_inline_same_line_and_wrapped_urls(self) -> None:
+        """Historical TITLE (N MINUTE READ) [https://...] patterns."""
+        _, issue = self._parse("TLDR/article_08-02-2023.md")
+        self.assertEqual(issue.format_family, "inline_url")
+        arts = {a.title: a for s in issue.sections for a in s.articles}
+
+        classic = arts["CLASSIC NEXT LINE ARTICLE"]
+        self.assertEqual(classic.reading_time_minutes, 5)
+        self.assertIn("theverge.com", classic.url or "")
+        self.assertEqual(classic.source_domain, "theverge.com")
+        self.assertIn("classic next-line", classic.summary.lower())
+        self.assertNotIn("http", classic.title.lower())
+
+        wrapped_same = arts[
+            "META ASKS MANY MANAGERS TO GET BACK TO MAKING THINGS OR LEAVE"
+        ]
+        self.assertEqual(wrapped_same.reading_time_minutes, 2)
+        self.assertTrue((wrapped_same.url or "").startswith("https://archive.ph/"))
+        self.assertEqual(wrapped_same.source_domain, "archive.ph")
+        self.assertIn("individual contributor", wrapped_same.summary.lower())
+        self.assertNotIn("http", wrapped_same.title.lower())
+        self.assertNotIn("archive.ph", wrapped_same.title.lower())
+
+        same_line = arts["SAME LINE ARCHIVE LINK"]
+        self.assertEqual(same_line.reading_time_minutes, 3)
+        self.assertIn("archive.ph/tHRU8", same_line.url or "")
+        self.assertEqual(same_line.source_domain, "archive.ph")
+        self.assertNotIn("http", same_line.title.lower())
+
+        wrapped_next = arts["WRAPPED READING TIME THEN NEXT LINE URL"]
+        self.assertEqual(wrapped_next.reading_time_minutes, 11)
+        self.assertIn("simplethread.com", wrapped_next.url or "")
+        self.assertNotIn("http", wrapped_next.title.lower())
+
+        ordinary = arts["ORDINARY DOMAIN SAME LINE"]
+        self.assertEqual(ordinary.reading_time_minutes, 4)
+        self.assertEqual(ordinary.url, "https://arxiv.org/abs/2302.00001")
+        self.assertEqual(ordinary.source_domain, "arxiv.org")
+        self.assertNotIn("http", ordinary.title.lower())
+
+        short = arts["SHORT NEXT LINE"]
+        self.assertEqual(short.reading_time_minutes, 1)
+        self.assertIn("example.com/quick-next", short.url or "")
+
+        for article in arts.values():
+            self.assertNotRegex(article.title, r"https?://")
+
+    def test_inline_next_line_urls_still_work(self) -> None:
+        """Regression: existing next-line inline URLs remain intact."""
+        _, issue = self._parse("TLDR AI/article_16-02-2023.md")
+        arts = [a for s in issue.sections for a in s.articles]
+        self.assertGreaterEqual(len(arts), 3)
+        by_title = {a.title: a for a in arts}
+        bing = by_title["BING AI IS UNHINGED"]
+        self.assertEqual(bing.reading_time_minutes, 3)
+        self.assertIn("theverge.com", bing.url or "")
+        self.assertEqual(bing.source_domain, "theverge.com")
+        self.assertIn("personality", bing.summary.lower())
+        self.assertNotIn("http", bing.title.lower())
+        human = by_title["HUMAN WRITER OR AI?"]
+        self.assertEqual(human.reading_time_minutes, 5)
+        self.assertIn("example.com/detectgpt", human.url or "")
+        short = by_title["SHORT ITEM"]
+        self.assertEqual(short.reading_time_minutes, 1)
+        self.assertIn("example.com/quick", short.url or "")
 
     def test_reference_link_parsing(self) -> None:
         _, issue = self._parse("TLDR AI/article_16-07-2026.md")

--- a/tools/tldr_derive/__init__.py
+++ b/tools/tldr_derive/__init__.py
@@ -1,6 +1,6 @@
 """Offline TLDR Markdown derivation toolkit (stdlib only)."""
 
 SCHEMA_VERSION = "1.0.0"
-GENERATOR_VERSION = "0.1.1"
+GENERATOR_VERSION = "0.1.2"
 
 __all__ = ["SCHEMA_VERSION", "GENERATOR_VERSION"]

--- a/tools/tldr_derive/parser_inline.py
+++ b/tools/tldr_derive/parser_inline.py
@@ -23,6 +23,13 @@ _TITLE_HINT_RE = re.compile(
     r"(MINUTE\s+READ|\(SPONSOR\)|\(GITHUB|\(COURSE\)|\(TOOL\)|\(APP\)|\(WEBSITE\))",
     re.IGNORECASE,
 )
+# Trailing editorial inline URL on a title line (possibly after markers).
+_TRAILING_BRACKET_URL_START_RE = re.compile(r"\[(https?://)", re.IGNORECASE)
+# Second line of a wrapped "(N MINUTE READ)" marker.
+_READING_TIME_CONTINUATION_RE = re.compile(
+    r"^MINUTE(?:S)?\s+READ\)\s*$",
+    re.IGNORECASE,
+)
 
 
 def _looks_like_title_start(line: str) -> bool:
@@ -75,6 +82,162 @@ def _consume_inline_url(lines: list[str], start: int) -> tuple[Optional[str], in
             return inner, j
         return None, start + 1
     return match.group(1), j
+
+
+def _consume_bracket_url_fragment(
+    lines: list[str],
+    start: int,
+    first_fragment: str,
+) -> tuple[Optional[str], int]:
+    """
+    Consume a bracketed URL that begins at first_fragment (must start with
+    '[http') and may continue across subsequent lines until ']'.
+    """
+    parts = [first_fragment.strip()]
+    j = start + 1
+    while "]" not in "".join(parts) and j < len(lines):
+        nxt = lines[j].strip()
+        if not nxt:
+            break
+        parts.append(nxt)
+        j += 1
+        if "]" in nxt:
+            break
+        if j - start > 8:
+            break
+    joined = "".join(p.strip() for p in parts)
+    match = re.match(r"^\[(https?://.+)\]\s*$", joined)
+    if match:
+        return match.group(1), j
+    inner = joined.strip("[]")
+    if inner.startswith("http"):
+        return inner, j
+    return None, start + 1
+
+
+def _split_trailing_inline_url(
+    line: str,
+) -> tuple[str, Optional[str], Optional[str]]:
+    """
+    If line contains a trailing [https://...] (complete or open), return
+    (title_prefix, complete_url_or_none, open_fragment_or_none).
+
+    open_fragment is set when '[' starts an http URL but ']' is missing so
+    the caller can continue on following lines.
+    """
+    match = _TRAILING_BRACKET_URL_START_RE.search(line)
+    if not match:
+        return line, None, None
+    idx = match.start()
+    prefix = line[:idx].rstrip()
+    rest = line[idx:]
+    if "]" in rest:
+        close = rest.find("]")
+        inner = rest[1:close]
+        if inner.lower().startswith("http"):
+            return prefix, inner, None
+        return line, None, None
+    if rest.lower().startswith("[http"):
+        return prefix, None, rest
+    return line, None, None
+
+
+def _marker_core_without_url(line: str) -> str:
+    """Title/marker text with any trailing [https://...] removed."""
+    prefix, inline_url, open_frag = _split_trailing_inline_url(line)
+    if inline_url is not None or open_frag is not None:
+        return prefix
+    return line
+
+
+def _is_reading_time_continuation(line: str) -> bool:
+    """True when line completes a wrapped reading-time marker (URL optional)."""
+    return bool(
+        _READING_TIME_CONTINUATION_RE.match(_marker_core_without_url(line).strip())
+    )
+
+
+def _take_trailing_url_from_line(
+    lines: list[str], index: int, line: str, title_parts: list[str]
+) -> tuple[Optional[str], int] | None:
+    """
+    If line has a trailing bracket URL, append marker prefix to title_parts and
+    return (url, next_index). Otherwise return None.
+    """
+    prefix, inline_url, open_frag = _split_trailing_inline_url(line)
+    if inline_url is None and open_frag is None:
+        return None
+    if prefix:
+        title_parts.append(prefix)
+    if inline_url is not None:
+        return inline_url, index + 1
+    assert open_frag is not None
+    url, after = _consume_bracket_url_fragment(lines, index, open_frag)
+    return url, after
+
+
+def _consume_title_and_url(
+    lines: list[str], start: int
+) -> tuple[str, Optional[str], int]:
+    """
+    Consume an inline-era title starting at start.
+
+    URL may appear:
+    - on the following line(s): TITLE\\n[https://...]
+    - trailing on the title line: TITLE (N MINUTE READ) [https://...]
+    - after a wrapped marker: TITLE (N\\nMINUTE READ) [https://...]
+    - with a wrapped URL body across lines after '['
+    """
+    title_parts: list[str] = []
+    first = lines[start].strip()
+
+    taken = _take_trailing_url_from_line(lines, start, first, title_parts)
+    if taken is not None:
+        url, after = taken
+        return " ".join(title_parts), url, after
+
+    title_parts.append(first)
+    j = start + 1
+
+    while j < len(lines):
+        nxt = lines[j].strip()
+        if not nxt:
+            break
+        if nxt.startswith("[http"):
+            # Classic next-line inline URL.
+            break
+        if is_section_heading(nxt) or is_emoji_only_line(nxt):
+            break
+
+        taken = _take_trailing_url_from_line(lines, j, nxt, title_parts)
+        if taken is not None:
+            url, after = taken
+            return " ".join(title_parts), url, after
+
+        if _is_reading_time_continuation(nxt):
+            title_parts.append(nxt)
+            j += 1
+            continue
+
+        if _looks_like_title_start(nxt) and _TITLE_HINT_RE.search(nxt):
+            # Another article title starting (has its own markers).
+            break
+
+        joined_so_far = " ".join(title_parts)
+        if _TITLE_HINT_RE.search(joined_so_far) and not _TITLE_HINT_RE.search(nxt):
+            # Likely finished title markers; stop unless clearly continuation.
+            if nxt.isupper() or len(nxt) < 40:
+                title_parts.append(nxt)
+                j += 1
+                continue
+            break
+
+        title_parts.append(nxt)
+        j += 1
+        if j - start > 6:
+            break
+
+    return " ".join(title_parts), None, j
 
 
 def parse_inline_url(
@@ -151,45 +314,22 @@ def parse_inline_url(
             i += 1
             continue
 
-        title_parts = [stripped]
-        j = i + 1
-        while j < len(lines):
-            nxt = lines[j].strip()
-            if not nxt:
-                break
-            if nxt.startswith("[http"):
-                break
-            if is_section_heading(nxt) or is_emoji_only_line(nxt):
-                break
-            if _looks_like_title_start(nxt) and _TITLE_HINT_RE.search(nxt):
-                break
-            # Continue title wrap until marker complete or URL.
-            if _TITLE_HINT_RE.search(" ".join(title_parts)) and not _TITLE_HINT_RE.search(
-                nxt
-            ):
-                # Likely finished title markers; stop unless clearly continuation.
-                if nxt.isupper() or len(nxt) < 40:
-                    title_parts.append(nxt)
-                    j += 1
-                    continue
-                break
-            title_parts.append(nxt)
-            j += 1
-            if j - i > 6:
-                break
-
-        title_joined = " ".join(title_parts)
-        reading_time = extract_reading_time(title_joined)
-        content_type, is_sponsor = classify_content(title_joined)
-        title = strip_markers_from_title(title_joined)
-
-        url_raw, after_url = _consume_inline_url(lines, j)
+        title_joined, url_raw, after_title = _consume_title_and_url(lines, i)
         src_line = line_offset + i + 1
 
         # Require a recognizable article marker for inline-era titles.
         if not _TITLE_HINT_RE.search(title_joined):
-            i = j
+            i = after_title
             continue
+
+        reading_time = extract_reading_time(title_joined)
+        content_type, is_sponsor = classify_content(title_joined)
+        title = strip_markers_from_title(title_joined)
+
+        if url_raw is None:
+            url_raw, after_url = _consume_inline_url(lines, after_title)
+        else:
+            after_url = after_title
 
         url = normalize_public_url(url_raw) if url_raw else None
         if url_raw and url is None:
@@ -211,7 +351,7 @@ def parse_inline_url(
                 )
             )
 
-        k = after_url if url_raw is not None else j
+        k = after_url if url_raw is not None else after_title
         if k < len(lines) and not lines[k].strip():
             k += 1
 


### PR DESCRIPTION
Historical newsletters often put the editorial URL after the reading-time marker instead of on the next line; parse it for any http(s) host and keep next-line URLs working.