### PR TITLE
Trigger validated web redeployments

### DIFF
--- a/.github/workflows/derive-ci.yml
+++ b/.github/workflows/derive-ci.yml
@@ -4,14 +4,24 @@ on:
   pull_request:
   push:
     branches:
-      - feat/tldr-derived-data-foundation
-      - feat/daily-ingestion-derived-sync
+      - main
+  workflow_dispatch:
+    inputs:
+      deploy_web:
+        description: Trigger the web deployment after successful validation
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  safe-derive-checks:
+  validate-derived-data:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,8 +43,98 @@ jobs:
       - name: Run offline daily pipeline tests
         run: python3 -m unittest tests_pipeline.test_daily_pipeline
 
+      - name: Run web redeployment workflow tests
+        run: python3 -m unittest tests_deploy.test_web_redeploy
+
       - name: Full-corpus strict privacy validation
         run: python3 -m tools.tldr_derive validate --all --strict-privacy
 
       - name: Generated structural consistency check
         run: python3 -m tools.check_generated_consistency --output generated
+
+  deploy-web:
+    needs: validate-derived-data
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_web == true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Request validated web deployment
+        env:
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          # DEPLOY_SCRIPT_BEGIN
+          set -euo pipefail
+
+          if [[ -z "${VERCEL_DEPLOY_HOOK_URL:-}" ]]; then
+            echo "::error::VERCEL_DEPLOY_HOOK_URL is not configured"
+            exit 1
+          fi
+
+          if ! response="$(
+            curl \
+              --request POST \
+              --fail-with-body \
+              --silent \
+              --show-error \
+              --connect-timeout 10 \
+              --max-time 60 \
+              --retry 3 \
+              --retry-delay 2 \
+              --retry-max-time 120 \
+              --retry-connrefused \
+              "${VERCEL_DEPLOY_HOOK_URL}" 2>&1
+          )"; then
+            echo "::error::Vercel deployment request failed"
+            exit 1
+          fi
+
+          RESPONSE_BODY="${response}" python3 - <<'PY'
+          # RESPONSE_VALIDATOR_BEGIN
+          import json
+          import os
+          import re
+          import sys
+
+          def fail() -> None:
+              print("::error::Vercel returned an invalid deployment response", file=sys.stderr)
+              raise SystemExit(1)
+
+          raw = os.environ.pop("RESPONSE_BODY", "")
+          try:
+              payload = json.loads(raw)
+          except (TypeError, json.JSONDecodeError):
+              fail()
+
+          if not isinstance(payload, dict):
+              fail()
+          if payload.get("error") or payload.get("errors"):
+              fail()
+
+          job = payload.get("job")
+          if not isinstance(job, dict) or job.get("error") or job.get("errors"):
+              fail()
+
+          job_id = job.get("id")
+          if not isinstance(job_id, str) or not job_id.strip():
+              fail()
+          job_id = job_id.strip()
+          if len(job_id) > 256 or not re.fullmatch(r"[A-Za-z0-9._:-]+", job_id):
+              fail()
+
+          state = job.get("state")
+          if state is not None:
+              if not isinstance(state, str):
+                  fail()
+              state = state.strip()
+              if len(state) > 64 or not re.fullmatch(r"[A-Za-z0-9._:-]+", state):
+                  fail()
+
+          print("Vercel deployment requested successfully")
+          print(f"job_id={job_id}")
+          if state:
+              print(f"state={state}")
+          # RESPONSE_VALIDATOR_END
+          PY
+          # DEPLOY_SCRIPT_END

--- a/.github/workflows/derive-ci.yml
+++ b/.github/workflows/derive-ci.yml
@@ -56,7 +56,9 @@ jobs:
     needs: validate-derived-data
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_dispatch' && inputs.deploy_web == true)
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/main' &&
+       inputs.deploy_web == true)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/docs/DAILY_PIPELINE.md
+++ b/docs/DAILY_PIPELINE.md
@@ -58,6 +58,79 @@ push_script.sh
 Empty staging does **not** skip pull/rebase/push retry. A previous local commit
 left unpushed is retried on the next cron minute.
 
+## Validated web redeployment
+
+The complete production path is:
+
+```text
+email
+  -> script.py
+  -> newsletter Markdown source
+  -> generated JSON
+  -> push_script.sh
+  -> tldr_news/main
+  -> GitHub Actions full-corpus validation
+  -> Vercel Deploy Hook
+  -> tldr-news-web build
+  -> immutable tldr_news source SHA
+  -> production
+```
+
+A push to `tldr_news/main` starts `.github/workflows/derive-ci.yml`. The workflow
+runs all derive tests, offline pipeline tests, strict privacy validation, and
+generated consistency checks before its separate `deploy-web` job can run. A
+failed or cancelled validation run cannot request a deployment. Concurrency
+cancels an older in-progress run for the same Git ref, so repeated main pushes
+do not deploy stale validated state.
+
+The repository Actions secret is named `VERCEL_DEPLOY_HOOK_URL`. It contains the
+Vercel Deploy Hook URL for the `tldr-news-web` project and its main branch. The
+URL is a credential: never print it, place it in logs, write it to a file, or
+commit it. Pull request workflows validate only and never receive a deployment
+request. The deployment response is parsed as JSON and only the accepted job ID
+and state are logged.
+
+The web build resolves the latest `tldr_news/main` ref to an immutable Git commit
+SHA before synchronizing `generated/`. `tldr_news` remains the source of truth
+for ingestion and normalized data; `tldr-news-web` remains responsible for
+presentation and search.
+
+### Manual workflow runs
+
+From GitHub, open **Actions → derive-ci → Run workflow** on the desired ref:
+
+- Leave **Trigger the web deployment after successful validation** disabled for
+  a validation-only run (the default).
+- Enable it to run validation and request a web deployment only after validation
+  succeeds.
+
+Equivalent GitHub CLI commands are:
+
+```bash
+# Validation only (default)
+gh workflow run derive-ci.yml --ref main
+
+# Validation followed by deployment
+gh workflow run derive-ci.yml --ref main -f deploy_web=true
+```
+
+A manual run with deployment enabled must be used deliberately. Unit tests and
+pull request CI never call the real hook.
+
+### Revoke or replace a compromised hook
+
+1. In the Vercel `tldr-news-web` project settings, revoke/delete the compromised
+   Deploy Hook.
+2. Create a replacement hook targeting the main branch.
+3. Replace the `VERCEL_DEPLOY_HOOK_URL` Actions secret in the `tldr_news`
+   repository settings.
+4. Run a manual validation-only workflow.
+5. Run a manual workflow with `deploy_web=true` and confirm that validation and
+   the deployment request both succeed.
+
+Do not put either the revoked or replacement URL in commits, issues,
+documentation, command output, or workflow inputs.
+
 ## Constants
 
 ```text

--- a/docs/DAILY_PIPELINE.md
+++ b/docs/DAILY_PIPELINE.md
@@ -97,12 +97,15 @@ presentation and search.
 
 ### Manual workflow runs
 
-From GitHub, open **Actions → derive-ci → Run workflow** on the desired ref:
+From GitHub, open **Actions → derive-ci → Run workflow**:
 
-- Leave **Trigger the web deployment after successful validation** disabled for
-  a validation-only run (the default).
-- Enable it to run validation and request a web deployment only after validation
-  succeeds.
+- Validation-only manual dispatches may run on any selected Git ref. Leave
+  **Trigger the web deployment after successful validation** disabled (the
+  default).
+- Deployment-enabled manual dispatches must select `main` and enable the option.
+  The deployment request runs only after validation succeeds.
+- A feature-branch manual run with `deploy_web=true` still validates that branch,
+  but the `deploy-web` job is skipped because the selected ref is not `main`.
 
 Equivalent GitHub CLI commands are:
 
@@ -114,8 +117,8 @@ gh workflow run derive-ci.yml --ref main
 gh workflow run derive-ci.yml --ref main -f deploy_web=true
 ```
 
-A manual run with deployment enabled must be used deliberately. Unit tests and
-pull request CI never call the real hook.
+A manual run with deployment enabled must be used deliberately and from `main`.
+Unit tests and pull request CI never call the real hook.
 
 ### Revoke or replace a compromised hook
 

--- a/tests_deploy/test_web_redeploy.py
+++ b/tests_deploy/test_web_redeploy.py
@@ -1,0 +1,178 @@
+"""Offline tests for validated web redeployment workflow behavior."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "derive-ci.yml"
+SECRET_CANARY = "https://example.invalid/a-secret-hook-value"
+
+
+def extract_marked_block(text: str, start: str, end: str) -> str:
+    """Extract and de-indent one marker-delimited workflow shell block."""
+    lines = text.splitlines()
+    start_index = next(i for i, line in enumerate(lines) if start in line)
+    end_index = next(i for i, line in enumerate(lines) if i > start_index and end in line)
+    return textwrap.dedent("\n".join(lines[start_index + 1 : end_index]))
+
+
+class WorkflowStructureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_validation_triggers_and_read_only_permissions(self) -> None:
+        self.assertIn("pull_request:", self.workflow)
+        self.assertRegex(self.workflow, r"push:\s+branches:\s+- main")
+        self.assertNotIn("feat/tldr-derived-data-foundation", self.workflow)
+        self.assertNotIn("feat/daily-ingestion-derived-sync", self.workflow)
+        self.assertRegex(self.workflow, r"permissions:\s+contents: read")
+        for forbidden in (
+            "contents: write",
+            "actions: write",
+            "deployments: write",
+            "pull-requests: write",
+        ):
+            self.assertNotIn(forbidden, self.workflow)
+
+    def test_manual_dispatch_defaults_to_validation_only(self) -> None:
+        self.assertRegex(
+            self.workflow,
+            r"(?s)workflow_dispatch:\s+inputs:\s+deploy_web:.*?default: false.*?type: boolean",
+        )
+
+    def test_deploy_job_depends_on_validation_and_excludes_pull_requests(self) -> None:
+        deploy = self.workflow.split("  deploy-web:", 1)[1]
+        self.assertIn("needs: validate-derived-data", deploy)
+        self.assertIn("github.event_name == 'push'", deploy)
+        self.assertIn("github.ref == 'refs/heads/main'", deploy)
+        self.assertIn("github.event_name == 'workflow_dispatch'", deploy)
+        self.assertIn("inputs.deploy_web == true", deploy)
+        self.assertNotIn("github.event_name == 'pull_request'", deploy)
+        self.assertNotIn("actions/checkout", deploy)
+        self.assertNotIn("always()", deploy)
+
+    def test_concurrency_cancels_older_runs_for_the_same_ref(self) -> None:
+        self.assertIn("group: ${{ github.workflow }}-${{ github.ref }}", self.workflow)
+        self.assertIn("cancel-in-progress: true", self.workflow)
+
+    def test_validation_commands_remain_strict(self) -> None:
+        for command in (
+            "bash -n automation.sh",
+            "bash -n push_script.sh",
+            "python3 -m unittest tests_derive.test_derive",
+            "python3 -m unittest tests_pipeline.test_daily_pipeline",
+            "python3 -m tools.tldr_derive validate --all --strict-privacy",
+            "python3 -m tools.check_generated_consistency --output generated",
+        ):
+            self.assertIn(command, self.workflow)
+        self.assertNotIn("continue-on-error", self.workflow)
+
+    def test_hook_request_is_bounded_and_uses_no_auth_header_or_payload(self) -> None:
+        deploy = self.workflow.split("  deploy-web:", 1)[1]
+        for option in (
+            "--request POST",
+            "--fail-with-body",
+            "--silent",
+            "--show-error",
+            "--connect-timeout 10",
+            "--max-time 60",
+            "--retry 3",
+            "--retry-connrefused",
+        ):
+            self.assertIn(option, deploy)
+        self.assertNotIn("Authorization", deploy)
+        self.assertNotIn("--data", deploy)
+
+
+class DeployShellTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.deploy_script = extract_marked_block(
+            workflow, "# DEPLOY_SCRIPT_BEGIN", "# DEPLOY_SCRIPT_END"
+        )
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        fake_curl = Path(self.temporary.name) / "curl"
+        fake_curl.write_text(
+            "#!/usr/bin/env bash\nprintf '%s' \"${FAKE_CURL_RESPONSE:-}\"\n",
+            encoding="utf-8",
+        )
+        fake_curl.chmod(fake_curl.stat().st_mode | stat.S_IXUSR)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_deploy(self, response: object | str, *, include_secret: bool = True) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["PATH"] = f"{self.temporary.name}:{env['PATH']}"
+        env["FAKE_CURL_RESPONSE"] = response if isinstance(response, str) else json.dumps(response)
+        if include_secret:
+            env["VERCEL_DEPLOY_HOOK_URL"] = SECRET_CANARY
+        else:
+            env.pop("VERCEL_DEPLOY_HOOK_URL", None)
+        return subprocess.run(
+            ["bash", "-c", self.deploy_script],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def assert_secret_not_logged(self, result: subprocess.CompletedProcess[str]) -> None:
+        self.assertNotIn(SECRET_CANARY, result.stdout)
+        self.assertNotIn(SECRET_CANARY, result.stderr)
+
+    def test_missing_secret_fails_before_request_without_logging_a_url(self) -> None:
+        result = self.run_deploy({"job": {"id": "unused"}}, include_secret=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("VERCEL_DEPLOY_HOOK_URL is not configured", result.stderr + result.stdout)
+        self.assert_secret_not_logged(result)
+
+    def test_malformed_json_fails_safely(self) -> None:
+        result = self.run_deploy("not-json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid deployment response", result.stderr)
+        self.assert_secret_not_logged(result)
+
+    def test_response_without_job_id_fails_safely(self) -> None:
+        result = self.run_deploy({"job": {"state": "PENDING"}})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid deployment response", result.stderr)
+        self.assert_secret_not_logged(result)
+
+    def test_explicit_error_response_fails_safely(self) -> None:
+        result = self.run_deploy({"error": {"message": "rejected"}})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid deployment response", result.stderr)
+        self.assertNotIn("rejected", result.stderr + result.stdout)
+        self.assert_secret_not_logged(result)
+
+    def test_valid_response_prints_only_safe_job_metadata(self) -> None:
+        result = self.run_deploy({"job": {"id": "job_123", "state": "QUEUED"}})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                "Vercel deployment requested successfully",
+                "job_id=job_123",
+                "state=QUEUED",
+            ],
+        )
+        self.assert_secret_not_logged(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_deploy/test_web_redeploy.py
+++ b/tests_deploy/test_web_redeploy.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 import subprocess
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -25,10 +27,36 @@ def extract_marked_block(text: str, start: str, end: str) -> str:
     return textwrap.dedent("\n".join(lines[start_index + 1 : end_index]))
 
 
+def extract_deploy_condition(text: str) -> str:
+    """Return the actual deploy-web job expression as one evaluable line."""
+    match = re.search(
+        r"(?m)^  deploy-web:\n[\s\S]*?^    if: >-\n(?P<condition>(?:^      [^\n]*\n)+)",
+        text,
+    )
+    if not match:
+        raise AssertionError("deploy-web condition was not found")
+    return " ".join(line.strip() for line in match.group("condition").splitlines())
+
+
 class WorkflowStructureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.deploy_condition = extract_deploy_condition(cls.workflow)
+
+    def deploys_for(self, event_name: str, ref: str, deploy_web: bool) -> bool:
+        expression = self.deploy_condition.replace("&&", " and ").replace("||", " or ")
+        expression = re.sub(r"\btrue\b", "True", expression)
+        return bool(
+            eval(
+                expression,
+                {"__builtins__": {}},
+                {
+                    "github": SimpleNamespace(event_name=event_name, ref=ref),
+                    "inputs": SimpleNamespace(deploy_web=deploy_web),
+                },
+            )
+        )
 
     def test_validation_triggers_and_read_only_permissions(self) -> None:
         self.assertIn("pull_request:", self.workflow)
@@ -50,16 +78,36 @@ class WorkflowStructureTests(unittest.TestCase):
             r"(?s)workflow_dispatch:\s+inputs:\s+deploy_web:.*?default: false.*?type: boolean",
         )
 
-    def test_deploy_job_depends_on_validation_and_excludes_pull_requests(self) -> None:
+    def test_deploy_job_depends_on_successful_validation(self) -> None:
         deploy = self.workflow.split("  deploy-web:", 1)[1]
         self.assertIn("needs: validate-derived-data", deploy)
-        self.assertIn("github.event_name == 'push'", deploy)
-        self.assertIn("github.ref == 'refs/heads/main'", deploy)
-        self.assertIn("github.event_name == 'workflow_dispatch'", deploy)
-        self.assertIn("inputs.deploy_web == true", deploy)
-        self.assertNotIn("github.event_name == 'pull_request'", deploy)
         self.assertNotIn("actions/checkout", deploy)
         self.assertNotIn("always()", deploy)
+
+    def test_manual_deployment_condition_structurally_requires_main(self) -> None:
+        self.assertRegex(
+            self.deploy_condition,
+            r"\(github\.event_name == 'workflow_dispatch'\s+&&\s+"
+            r"github\.ref == 'refs/heads/main'\s+&&\s+inputs\.deploy_web == true\)",
+        )
+
+    def test_push_to_main_may_deploy(self) -> None:
+        self.assertTrue(self.deploys_for("push", "refs/heads/main", False))
+        self.assertFalse(self.deploys_for("push", "refs/heads/feature", True))
+
+    def test_manual_deployment_on_main_may_deploy(self) -> None:
+        self.assertTrue(self.deploys_for("workflow_dispatch", "refs/heads/main", True))
+
+    def test_manual_deployment_on_non_main_ref_cannot_deploy(self) -> None:
+        self.assertFalse(
+            self.deploys_for("workflow_dispatch", "refs/heads/feature/test", True)
+        )
+
+    def test_manual_dispatch_with_deploy_disabled_cannot_deploy(self) -> None:
+        self.assertFalse(self.deploys_for("workflow_dispatch", "refs/heads/main", False))
+
+    def test_pull_requests_cannot_deploy(self) -> None:
+        self.assertFalse(self.deploys_for("pull_request", "refs/pull/8/merge", True))
 
     def test_concurrency_cancels_older_runs_for_the_same_ref(self) -> None:
         self.assertIn("group: ${{ github.workflow }}-${{ github.ref }}", self.workflow)


### PR DESCRIPTION
## Summary

- Updates `derive-ci` to validate every pull request, every push to `main`, and manual dispatches.
- Adds a separate validated Vercel redeployment job without changing VPS ingestion behavior.
- Documents the complete source-to-production path and operational recovery steps.

## Workflow triggers

- `pull_request`: validation only; deployment is structurally excluded.
- `push` to `main`: validation followed by deployment only after validation succeeds.
- `workflow_dispatch`: `deploy_web` defaults to `false`; setting it to `true` requests deployment after successful validation.
- Removed obsolete feature-branch push triggers.

## Validation job

The stable `validate-derived-data` job retains all existing checks without `continue-on-error`:

- Bash syntax checks for `automation.sh` and `push_script.sh`
- derive unit tests
- offline daily pipeline tests
- full-corpus `--strict-privacy` validation
- generated structural consistency validation
- new offline workflow/deployment-response tests

## Deployment job

`deploy-web` has `needs: validate-derived-data` and no `always()` condition, so failed or cancelled validation cannot call the hook. It runs only for a push to `refs/heads/main` or a manual dispatch with `deploy_web=true`. Pull requests cannot run it.

The job requires no checkout, uses a five-minute timeout, and receives only the `VERCEL_DEPLOY_HOOK_URL` step-scoped environment variable. Missing-secret failures and request failures use fixed messages that never include the URL.

## Concurrency

Runs are grouped by workflow and Git ref with `cancel-in-progress: true`, preventing an older in-progress run for the same ref from continuing after a newer source state arrives.

## Safe response handling

The hook request uses a bounded HTTP POST with transient retries, no payload, and no Authorization header. Inline standard-library Python validates that the response:

- is JSON;
- has no explicit error;
- contains a `job` object;
- contains a non-empty, log-safe `job.id`.

Only a success message, job ID, and optional state are logged. The complete response and hook URL are never printed.

## Verification

Completed locally:

- `bash -n automation.sh`
- `bash -n push_script.sh`
- `python3 -m unittest tests_derive.test_derive` — 46 tests passed
- `python3 -m unittest tests_pipeline.test_daily_pipeline` — 19 tests passed
- `python3 -m tools.tldr_derive validate --all --strict-privacy` — 5,929/5,929 processed, zero errors, zero privacy hits
- `python3 -m tools.check_generated_consistency --output generated` — passed
- `python3 -m unittest tests_deploy.test_web_redeploy` — 11 tests passed
- workflow YAML parse — passed

The new tests cover trigger/job structure, read-only permissions, validation dependency, PR exclusion, push/manual conditions, default validation-only dispatch, missing secrets, malformed JSON, missing job IDs, explicit errors, valid responses, and secret non-disclosure.

The real Vercel Deploy Hook was not called from this branch or from tests.

## Security and permissions

- Repository permissions remain `contents: read` only.
- No write permission was added.
- The secret name is `VERCEL_DEPLOY_HOOK_URL`; no hook URL is committed or documented.
- `tldr_news` remains the data source of truth.
- `tldr-news-web` remains responsible for presentation and search.

## Manual post-merge verification

1. Confirm the merged `derive-ci` workflow validates successfully on `main`.
2. Confirm `deploy-web` runs only after `validate-derived-data` succeeds.
3. Confirm its safe output includes a Vercel job ID without exposing the hook URL.
4. Confirm the `tldr-news-web` Vercel build starts and logs the latest immutable `tldr_news` source SHA.
5. Run a manual validation-only dispatch with the default `deploy_web=false` and confirm deployment is skipped.
6. Run a deliberate manual dispatch with `deploy_web=true` and confirm validation precedes the deployment request.
