### PR TITLE
Protect staged raw newsletters from private URLs

### DIFF
--- a/docs/DAILY_PIPELINE.md
+++ b/docs/DAILY_PIPELINE.md
@@ -28,6 +28,9 @@ automation.sh
   flock (required)
   -> tee stdout/stderr to logs/automation.log
   -> python3 script.py
+     -> normalize raw line endings/whitespace
+     -> remove known subscriber URLs and canonicalize controlled private URLs
+     -> reject unresolved credential URLs without deleting the IMAP message
   -> python3 -m tools.tldr_derive generate --changed --output generated
   -> logs/last_automation_success
   (no git)
@@ -41,6 +44,7 @@ push_script.sh
   -> optional latest-date editorial/illustration publication
   -> validate editorial consistency
   -> stage approved TLDR* dirs + normalized/editorial JSON only
+  -> scan exact staged raw blobs: python -m tools.tldr_raw_privacy check-staged
   -> if staged changes:
        repeat normalized + editorial consistency checks
        generate --changed; require selected=0 written=0 failures=[]
@@ -63,7 +67,14 @@ left unpushed is retried on the next cron minute. The existing flock covers the
 entire source/editorial/rebase/push operation. Provider or R2 failure becomes a
 valid fallback/editorial-only artifact and does not discard normalized ingestion;
 a structural consistency failure still blocks commit/push. Image binaries are
-never staged. See [the editorial operations guide](EDITORIAL_PIPELINE.md).
+never staged. The raw gate reads `git diff --cached --name-only -z` and indexed
+blobs rather than worktree bytes. It applies only to newly added or modified
+Markdown under `TLDR` / `TLDR *`; it does not retroactively rewrite the corpus.
+Operators can explicitly normalize selected files with
+`python -m tools.tldr_raw_privacy sanitize [--check] <path>...`. This command is
+NUL/path safe, refuses symlinks and paths outside approved source directories,
+and never reports removed parameter values. Re-derive normalized output after
+sanitizing. See [the editorial operations guide](EDITORIAL_PIPELINE.md).
 
 ## Validated web redeployment
 

--- a/push_script.sh
+++ b/push_script.sh
@@ -52,6 +52,8 @@ run_source_and_editorial_publication
 stage_approved_sources
 stage_generated
 stage_editorial
+run_raw_source_privacy
+log "staged raw-source privacy gate passed"
 
 if git diff --cached --quiet; then
   log "no staged changes before rebase"
@@ -74,6 +76,8 @@ else
 
   stage_generated
   stage_editorial
+  run_raw_source_privacy
+  log "pre-commit raw-source privacy gate passed"
   msg="Daily TLDR update $(date -u +'%Y-%m-%d %H:%M') UTC"
   git commit -m "${msg}"
   log "committed: ${msg}"
@@ -104,6 +108,8 @@ log "changed_clean after rebase"
 stage_generated
 stage_editorial
 if ! git diff --cached --quiet; then
+  run_raw_source_privacy
+  log "post-rebase pre-commit raw-source privacy gate passed"
   sync_msg="Daily TLDR generated sync $(date -u +'%Y-%m-%d %H:%M') UTC"
   git commit -m "${sync_msg}"
   log "committed post-rebase generated sync: ${sync_msg}"

--- a/script.py
+++ b/script.py
@@ -1,110 +1,73 @@
-#     script.py
-#
-#   Target dan@tldrnewsletter.com puis enregistre automatiquement ses mails
-#
-#
+"""Fetch new TLDR newsletters and write privacy-safe raw source files."""
+from __future__ import annotations
 
-import os
-
-import imaplib
 import email
+import imaplib
+import os
+import quopri
+import re
+import tempfile
+from datetime import datetime
+from pathlib import Path
 
 from dotenv import dotenv_values
-
-import html
-import re
-import urllib.parse
-from bs4 import BeautifulSoup 
-
-from datetime import datetime
-import ast # To transform ids string from ids.txt in bytes
-import quopri
-
-##########################################
-####        CONFIG      #################
-########################################
-config = dotenv_values(".env")
-password = config['KEY']
-username = config['email']
-
-########################################
-######      CONNEXION       ############
-########################################
-imap = imaplib.IMAP4_SSL("74.125.20.108")
-imap.login(username, password)
-imap.select("inbox")
-
-#########################################
-######      CATCH DATA          #########
-#########################################
-# Search for latest email from dan@tldrnewsletter.com
-typ, data = imap.search(None, 'FROM "dan@tldrnewsletter.com"') 
-#print(data)
-
-topics = ["AI", "Crypto", "Design", "Cybersecurity", "Founders", "Web Dev", "Marketing","InfoSec", ""]
-
-all_ids = data[0].decode().split()
-all_ids = [int(id_) for id_ in all_ids]
-print(f"All ids : {all_ids}")
+from tools.tldr_raw_privacy import RawPrivacyError,format_finding,is_approved_source,prepare_raw_source
 
 
-is_written = False
+def _atomic_write(path:Path,text:str)->None:
+ path.parent.mkdir(parents=True,exist_ok=True)
+ fd,tmp=tempfile.mkstemp(prefix=".tldr-raw-",dir=path.parent)
+ try:
+  with os.fdopen(fd,"w",encoding="utf-8",newline="") as handle:
+   handle.write(text);handle.flush();os.fsync(handle.fileno())
+  os.replace(tmp,path)
+ finally:
+  if os.path.exists(tmp):os.unlink(tmp)
 
-for num in all_ids[::-1]:
-  print(num)
-  is_written = False
-  _, email_data = imap.fetch(str(num), '(RFC822)')
-  raw_email = email_data[0][1]
-  msg = email.message_from_bytes(raw_email)
-  date_envoi = datetime.strptime(msg['Date'], '%a, %d %b %Y %H:%M:%S %z')
-  print('Date envoi : ', date_envoi)
-  
 
-  sender = msg['From']
-  pattern = r' <dan@tldrnewsletter.com>'
-  sender = re.sub(pattern,'', sender)
-  pattern = r'=?utf-\w+\?Q\?.+\?='
-  sender = re.sub(pattern, '', sender)
-  sender = sender.replace(' =?', '')
-  print(sender)
-  
+def persist_newsletter(imap,num:str,path:Path,text:str)->bool:
+ """Prepare/write one newsletter, deleting mail only after a safe write."""
+ if not is_approved_source(path.as_posix()) or path.is_symlink() or any(parent.is_symlink() for parent in path.parents if parent!=Path(".")):
+  print(f"raw_privacy_violation path={path.as_posix()} category=path_outside_approved_sources host=unknown")
+  return False
+ try:prepared,categories=prepare_raw_source(text)
+ except RawPrivacyError as exc:
+  print(format_finding(exc.finding,path.as_posix()))
+  return False
+ _atomic_write(path,prepared)
+ print(f"raw_newsletter_written path={path.as_posix()} categories={','.join(categories or ['none'])}")
+ imap.store(num,"+FLAGS","\\Deleted");imap.expunge()
+ return True
 
-  newsletter = ""
-  
-  for part in msg.walk():
-    if part.get_content_type()=='text/plain':
-      part_text = part.get_payload()
-      part_decoded = quopri.decodestring(part_text)
-      part_string = part_decoded.decode('utf-8')
-      newsletter = part_string
-  
-#  print('La newsletter du ', date_envoi, ' est \n\n ', newsletter)
-    
-  date_for_filename = date_envoi.date()
-    
-  topic = sender
-  filename = f"article_{date_for_filename.strftime('%d-%m-%Y')}.md"
-  folder = f"{topic}"
-  
-  # Créer le dossier s'il n'existe pas
-  if not os.path.exists(folder):
-    os.makedirs(folder)
-  
-  # Enregistrer le fichier
-  filepath = os.path.join(folder, filename)
-  with open(filepath, "w") as f:
-    f.write(f"# Articles {topic} {date_for_filename.strftime('%d-%m-%Y')}\n\n")
-    f.write(newsletter)
-    is_written= True
-                    
-  print("is writen  : ", is_written)
-  if is_written:
-    imap.store(str(num), "+FLAGS", "\\Deleted")
-    imap.expunge()
-    print('Email ', str(num), ' is deleted!')
-# close the mailbox
-imap.close()
-# logout from the account
-imap.logout()
- 
-print('Latest email articles extracted!')
+
+def _plain_text(msg)->str:
+ newsletter=""
+ for part in msg.walk():
+  if part.get_content_type()=="text/plain":
+   payload=part.get_payload()
+   if isinstance(payload,str):newsletter=quopri.decodestring(payload).decode("utf-8")
+ return newsletter
+
+
+def main()->int:
+ config=dotenv_values(".env");imap=imaplib.IMAP4_SSL("74.125.20.108")
+ imap.login(config["email"],config["KEY"]);imap.select("inbox")
+ failed=False
+ try:
+  typ,data=imap.search(None,'FROM "dan@tldrnewsletter.com"')
+  if typ!="OK":return 1
+  ids=[int(value) for value in data[0].decode().split()]
+  for number in reversed(ids):
+   num=str(number);_,email_data=imap.fetch(num,"(RFC822)");msg=email.message_from_bytes(email_data[0][1])
+   sent=datetime.strptime(msg["Date"],"%a, %d %b %Y %H:%M:%S %z")
+   sender=re.sub(r" <dan@tldrnewsletter.com>","",msg["From"])
+   sender=re.sub(r"=?utf-\w+\?Q\?.+\?=","",sender).replace(" =?","")
+   filename=f"article_{sent.date().strftime('%d-%m-%Y')}.md";path=Path(sender)/filename
+   source=f"# Articles {sender} {sent.date().strftime('%d-%m-%Y')}\n\n{_plain_text(msg)}"
+   if not persist_newsletter(imap,num,path,source):failed=True
+ finally:
+  imap.close();imap.logout()
+ return 1 if failed else 0
+
+
+if __name__=="__main__":raise SystemExit(main())

--- a/scripts/pipeline_lib.sh
+++ b/scripts/pipeline_lib.sh
@@ -121,6 +121,10 @@ print("changed_clean")
 '
 }
 
+run_raw_source_privacy() {
+  "${PYTHON_BIN}" -m tools.tldr_raw_privacy check-staged
+}
+
 run_validate() {
   "${PYTHON_BIN}" -m tools.tldr_derive validate --all --strict-privacy
 }

--- a/tests_derive/test_raw_privacy.py
+++ b/tests_derive/test_raw_privacy.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import contextlib,io,os,subprocess,tempfile,unittest
+from pathlib import Path
+from tools.check_generated_consistency import check_generated
+from tools.tldr_raw_privacy import RawPrivacyError,check_staged,inspect_raw_privacy,prepare_raw_source,sanitize_paths
+from tools.tldr_derive.sanitizer import normalize_public_url
+from script import persist_newsletter
+
+OBSERVED="https://stratechery.com/2026/public-article/?access_token=DO_NOT_ECHO&utm_source=newsletter"
+
+class RawPrivacyTests(unittest.TestCase):
+ def setUp(self):
+  self.old=Path.cwd();self.tmp=tempfile.TemporaryDirectory();self.root=Path(self.tmp.name);os.chdir(self.root)
+ def tearDown(self):os.chdir(self.old);self.tmp.cleanup()
+ def git(self,*args):return subprocess.run(["git",*args],check=True,capture_output=True,text=True)
+ def init_git(self):
+  self.git("init","-b","main");self.git("config","user.email","raw-test@example.com");self.git("config","user.name","Raw Test")
+ def stage(self,path="TLDR/article.md",text=OBSERVED):
+  p=self.root/path;p.parent.mkdir(parents=True,exist_ok=True);p.write_text(text+"\n");self.git("add","--",path);return p
+ def check_output(self):
+  err=io.StringIO()
+  with contextlib.redirect_stderr(err):code=check_staged()
+  return code,err.getvalue()
+ def test_staged_index_catches_sensitive_parameter_without_value(self):
+  self.init_git();self.stage();code,error=self.check_output();self.assertEqual(code,1);self.assertIn("host=stratechery.com",error);self.assertIn("key=access_token",error);self.assertNotIn("DO_NOT_ECHO",error);self.assertNotIn("https://",error)
+ def test_scanner_reads_index_when_worktree_differs(self):
+  self.init_git();p=self.stage();p.write_text("https://example.com/public?code=ok\n");code,error=self.check_output();self.assertEqual(code,1);self.assertIn("credential_query_parameter",error);self.assertNotIn("DO_NOT_ECHO",error)
+ def test_paths_containing_spaces_are_nul_safe(self):
+  self.init_git();self.stage("TLDR AI/article with spaces.md");code,error=self.check_output();self.assertEqual(code,1);self.assertIn("path=TLDR AI/article with spaces.md",error)
+ def test_url_userinfo_rejected_without_password_in_error(self):
+  finding=inspect_raw_privacy("https://user:DO_NOT_ECHO@example.com/article")[0];self.assertEqual(finding.category,"url_userinfo");self.assertNotIn("DO_NOT_ECHO",str(finding))
+  with self.assertRaises(RawPrivacyError) as caught:prepare_raw_source("https://user:DO_NOT_ECHO@example.com/article")
+  self.assertNotIn("DO_NOT_ECHO",str(caught.exception))
+ def test_known_management_and_subscriber_urls_are_removed(self):
+  source="Article\nhttps://tldr.tech/tech/manage?email=DO_NOT_ECHO\nhttps://refer.tldr.tech/private/path\n"
+  clean,categories=prepare_raw_source(source);self.assertNotIn("DO_NOT_ECHO",clean);self.assertNotIn("refer.tldr.tech",clean);self.assertIn("subscriber_or_management_url",categories)
+ def test_observed_host_key_is_canonicalized(self):
+  clean,categories=prepare_raw_source(OBSERVED);self.assertEqual(clean,"https://stratechery.com/2026/public-article/?utm_source=newsletter\n");self.assertEqual(categories,["credential_parameter_removed"])
+  encoded=OBSERVED.replace("&utm_source","&amp;utm_source");self.assertNotIn("access_token",prepare_raw_source(encoded)[0])
+ def test_ordinary_and_ambiguous_public_parameters_remain(self):
+  url="https://example.com/article?token=a&uid=b&user_id=c&key=d&code=e&utm_source=f"
+  clean,_=prepare_raw_source(url);self.assertEqual(clean,url+"\n")
+ def test_unknown_credential_url_is_rejected_not_redacted(self):
+  with self.assertRaises(RawPrivacyError):prepare_raw_source("https://example.com/private?api_key=DO_NOT_ECHO")
+ def test_whitespace_normalization_is_deterministic_and_idempotent(self):
+  raw="Header  \r\n\r\nArticle\t\r\n\r\n\r\n";once,_=prepare_raw_source(raw);twice,_=prepare_raw_source(once);self.assertEqual(once,"Header\n\nArticle\n");self.assertEqual(once,twice)
+ def test_explicit_sanitize_check_and_atomic_write(self):
+  self.init_git();p=self.stage(text="Header  \n"+OBSERVED);before=p.read_bytes();out=io.StringIO()
+  with contextlib.redirect_stdout(out):self.assertEqual(sanitize_paths([str(p)],check=True),1)
+  self.assertEqual(p.read_bytes(),before);self.assertNotIn("DO_NOT_ECHO",out.getvalue())
+  with contextlib.redirect_stdout(out):self.assertEqual(sanitize_paths([str(p)]),0)
+  first=p.read_bytes()
+  with contextlib.redirect_stdout(out):self.assertEqual(sanitize_paths([str(p)]),0)
+  self.assertEqual(p.read_bytes(),first);self.assertIn(b"Header\n",first);self.assertNotIn("DO_NOT_ECHO",out.getvalue())
+ def test_sanitize_refuses_symlink(self):
+  self.init_git();target=self.root/"target.md";target.write_text("safe\n");link=self.root/"TLDR"/"link.md";link.parent.mkdir();link.symlink_to(target)
+  err=io.StringIO()
+  with contextlib.redirect_stderr(err):self.assertEqual(sanitize_paths([str(link)]),1)
+  self.assertIn("path_outside_approved_sources",err.getvalue())
+ class FakeImap:
+  def __init__(self):self.calls=[]
+  def store(self,*args):self.calls.append(("store",args))
+  def expunge(self):self.calls.append(("expunge",()))
+ def test_unsafe_ingestion_does_not_write_or_delete_message(self):
+  fake=self.FakeImap();path=Path("TLDR/article.md");out=io.StringIO()
+  with contextlib.redirect_stdout(out):written=persist_newsletter(fake,"42",path,"https://example.com/private?client_secret=DO_NOT_ECHO")
+  self.assertFalse(written);self.assertFalse(path.exists());self.assertEqual(fake.calls,[]);self.assertNotIn("DO_NOT_ECHO",out.getvalue());self.assertNotIn("https://",out.getvalue())
+ def test_normalized_url_policy_canonicalizes_observed_and_rejects_unknown_credentials(self):
+  self.assertEqual(normalize_public_url(OBSERVED),"https://stratechery.com/2026/public-article/?utm_source=newsletter")
+  self.assertIsNone(normalize_public_url("https://example.com/private?api_key=DO_NOT_ECHO"))
+  self.assertEqual(normalize_public_url("https://example.com/public?token=a&uid=b&user_id=c&key=d&code=e"),"https://example.com/public?token=a&uid=b&user_id=c&key=d&code=e")
+ def test_normalized_derivation_after_sanitation_is_consistent(self):
+  source=self.root/"TLDR"/"article_01-01-2024.md";source.parent.mkdir();raw="# Articles TLDR 01-01-2024\n\nTLDR 2024-01-01\n\nNEWS\n\nPUBLIC STORY (2 MINUTE READ) [1]\n\nA public summary.\n\nLinks:\n------\n[1] "+OBSERVED+"\n";source.write_text(prepare_raw_source(raw)[0])
+  repo=Path(__file__).resolve().parents[1];env={**os.environ,"PYTHONPATH":str(repo)}
+  run=subprocess.run([os.sys.executable,"-m","tools.tldr_derive","--repo-root",str(self.root),"--output",str(self.root/"generated"),"generate","--all"],env=env,capture_output=True,text=True)
+  self.assertEqual(run.returncode,0,msg=run.stderr);self.assertEqual(check_generated(self.root/"generated"),[]);self.assertNotIn("access_token",source.read_text());self.assertTrue(all("access_token" not in p.read_text() for p in (self.root/"generated").rglob("*.json")))
+
+if __name__=="__main__":unittest.main()

--- a/tests_pipeline/test_daily_pipeline.py
+++ b/tests_pipeline/test_daily_pipeline.py
@@ -109,6 +109,8 @@ class ScriptStaticGuards(unittest.TestCase):
         self.assertNotIn("generated/editorial/images", lib)
         self.assertNotIn("if ! run_editorial_latest", lib)
         self.assertIn("run_editorial_latest\n", lib)
+        self.assertIn("tools.tldr_raw_privacy check-staged", lib)
+        self.assertGreaterEqual(text.count("run_raw_source_privacy"), 3)
 
 
 class ConsistencyModuleTests(unittest.TestCase):
@@ -236,6 +238,8 @@ class PipelineTempRepoTests(unittest.TestCase):
                     "generate_calls": 0,
                     "validate_calls": 0,
                     "consistency_calls": 0,
+                    "raw_privacy_calls": 0,
+                    "raw_privacy_exit": 0,
                     "editorial_generate_calls": 0,
                     "editorial_validate_calls": 0,
                     "editorial_generate_exit": 7,
@@ -319,6 +323,11 @@ class PipelineTempRepoTests(unittest.TestCase):
             if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "tools.check_generated_consistency" ]]; then
               py_update consistency_calls 1 >/dev/null
               exit "$(py_get consistency_exit)"
+            fi
+
+            if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "tools.tldr_raw_privacy" && "${{3:-}}" == "check-staged" ]]; then
+              py_update raw_privacy_calls 1 >/dev/null
+              exit "$(py_get raw_privacy_exit)"
             fi
 
             if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "tools.tldr_editorial" ]]; then
@@ -536,6 +545,18 @@ class PipelineTempRepoTests(unittest.TestCase):
         proc = self._run("push_script.sh")
         self.assertNotEqual(proc.returncode, 0)
         self.assertEqual(before, self._rev())
+        self.assertFalse((self.repo / "logs" / "last_push_success").exists())
+
+    def test_raw_privacy_failure_blocks_before_commit(self) -> None:
+        (self.repo / "TLDR" / "article_sensitive.md").write_text(
+            "# staged raw source\n", encoding="utf-8"
+        )
+        before = self._rev()
+        self._set_state(raw_privacy_exit=4)
+        proc = self._run("push_script.sh")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(before, self._rev())
+        self.assertEqual(self._state()["raw_privacy_calls"], 1)
         self.assertFalse((self.repo / "logs" / "last_push_success").exists())
 
     def test_validation_failure_prevents_commit(self) -> None:

--- a/tools/tldr_derive/sanitizer.py
+++ b/tools/tldr_derive/sanitizer.py
@@ -22,6 +22,18 @@ _SUBSCRIBER_PARAM_KEYS = {
     "subscriber_id",
 }
 
+_CREDENTIAL_PARAM_KEYS = {
+    "access_token", "refresh_token", "id_token", "api_key", "apikey",
+    "client_secret", "auth_token", "authorization", "password", "passwd",
+    "session", "session_id", "sessionid", "jwt", "signature",
+    "x-amz-signature", "x-amz-credential", "x-amz-security-token",
+    "x-goog-signature", "x-goog-credential",
+}
+_OBSERVED_PUBLIC_CANONICAL = {
+    ("stratechery.com", "access_token"),
+    ("www.stratechery.com", "access_token"),
+}
+
 _PRIVATE_PATH_RE = re.compile(
     r"(^|/)(unsubscribe|manage|preferences?|account|settings|email-preferences)"
     r"(/|$|\?)",
@@ -112,11 +124,16 @@ def normalize_public_url(url: Optional[str]) -> Optional[str]:
     parts = urlsplit(repaired)
     if parts.scheme not in ("http", "https"):
         return None
-    if not parts.netloc:
+    if not parts.netloc or parts.username is not None or parts.password is not None:
         return None
 
-    host = _host(parts.netloc)
+    host = (parts.hostname or "").lower()
     query_pairs = parse_qsl(parts.query, keep_blank_values=True)
+    credential_keys = {k.lower() for k, _ in query_pairs} & _CREDENTIAL_PARAM_KEYS
+    if credential_keys:
+        if any((host, key) not in _OBSERVED_PUBLIC_CANONICAL for key in credential_keys):
+            return None
+        query_pairs = [(k, v) for k, v in query_pairs if k.lower() not in credential_keys]
     if _is_management_host(host):
         query_pairs = [
             (k, v)

--- a/tools/tldr_raw_privacy.py
+++ b/tools/tldr_raw_privacy.py
@@ -1,0 +1,150 @@
+"""Privacy preparation and staged-index gate for raw TLDR newsletters."""
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote_plus, urlsplit, urlunsplit
+
+_URL_RE=re.compile(r"https?://[^\s<>\"']+",re.IGNORECASE)
+_ALWAYS_SENSITIVE={"access_token","refresh_token","id_token","api_key","apikey","client_secret","auth_token","authorization","password","passwd","session","session_id","sessionid","jwt","signature","x_amz_signature","x_amz_credential","x_amz_security_token","x_goog_signature","x_goog_credential"}
+_SUBSCRIBER_KEYS={"email","email_address","subscriber","subscriber_id","contact_id"}
+_OBSERVED_CANONICAL={("stratechery.com","access_token"),("www.stratechery.com","access_token")}
+_PRIVATE_HOSTS={"refer.tldr.tech","hub.sparklp.co"}
+_MANAGEMENT_PATH=re.compile(r"(^|/)(unsubscribe|manage|preferences?|subscriptions?|account|settings|email-preferences)(/|$)",re.I)
+
+@dataclass(frozen=True)
+class Finding:
+ category:str
+ host:str
+ key:str|None=None
+
+class RawPrivacyError(Exception):
+ def __init__(self,finding:Finding):self.finding=finding;super().__init__(format_finding(finding))
+
+def _key(raw:str)->str:return unquote_plus(raw.split("=",1)[0]).strip().lower().replace("-","_")
+def _query_pairs(query:str)->list[tuple[str,str]]:
+ return [(_key(q),q) for q in html.unescape(query).split("&") if q]
+def _host(parts)->str:return (parts.hostname or "").lower()
+def _private_url(parts,pairs:list[tuple[str,str]])->bool:
+ host=_host(parts);path=parts.path or ""
+ if host in _PRIVATE_HOSTS:return True
+ if host.endswith(".tldrnewsletter.com") and (path.startswith("/web-version") or _MANAGEMENT_PATH.search(path)):return True
+ if (host=="tldr.tech" or host.endswith(".tldr.tech")) and _MANAGEMENT_PATH.search(path):return True
+ return any(k in _SUBSCRIBER_KEYS for k,_ in pairs)
+
+def inspect_raw_privacy(text:str)->list[Finding]:
+ findings=[]
+ for match in _URL_RE.finditer(text):
+  raw=match.group(0).rstrip(").,;]")
+  try:parts=urlsplit(raw)
+  except ValueError:
+   findings.append(Finding("invalid_url",""));continue
+  host=_host(parts);pairs=_query_pairs(parts.query)
+  if parts.username is not None or parts.password is not None:findings.append(Finding("url_userinfo",host))
+  if _private_url(parts,pairs):findings.append(Finding("subscriber_or_management_url",host,next((k for k,_ in pairs if k in _SUBSCRIBER_KEYS),None)))
+  for key,_ in pairs:
+   if key in _ALWAYS_SENSITIVE:findings.append(Finding("credential_query_parameter",host,key))
+ return list(dict.fromkeys(findings))
+
+def _sanitize_url(raw:str)->tuple[str,list[str]]:
+ suffix=raw[len(raw.rstrip(").,;]")):];url=raw[:len(raw)-len(suffix)] if suffix else raw
+ parts=urlsplit(url);host=_host(parts);pairs=_query_pairs(parts.query)
+ if parts.username is not None or parts.password is not None:raise RawPrivacyError(Finding("url_userinfo",host))
+ if _private_url(parts,pairs):return suffix,["subscriber_or_management_url"]
+ sensitive={k for k,_ in pairs if k in _ALWAYS_SENSITIVE}
+ if sensitive:
+  unresolved=sorted(k for k in sensitive if (host,k) not in _OBSERVED_CANONICAL)
+  if unresolved:raise RawPrivacyError(Finding("credential_query_parameter",host,unresolved[0]))
+  kept=[raw_pair for k,raw_pair in pairs if k not in sensitive]
+  url=urlunsplit((parts.scheme,parts.netloc,parts.path,"&".join(kept),parts.fragment))
+  return url+suffix,["credential_parameter_removed"]
+ return url+suffix,[]
+
+def prepare_raw_source(text:str)->tuple[str,list[str]]:
+ """Normalize and sanitize one complete raw newsletter deterministically."""
+ text=text.replace("\r\n","\n").replace("\r","\n");categories=[]
+ def replace(match):
+  replacement,found=_sanitize_url(match.group(0));categories.extend(found);return replacement
+ text=_URL_RE.sub(replace,text)
+ lines=[re.sub(r"[ \t]+$","",line) for line in text.split("\n")]
+ while lines and lines[-1]=="":lines.pop()
+ return "\n".join(lines)+"\n",sorted(set(categories))
+
+def is_approved_source(path:str)->bool:
+ p=Path(path)
+ return not p.is_absolute() and len(p.parts)>=2 and (p.parts[0]=="TLDR" or p.parts[0].startswith("TLDR ")) and p.suffix.lower()==".md" and ".." not in p.parts
+
+def staged_source_paths()->list[str]:
+ raw=subprocess.run(["git","diff","--cached","--name-only","-z","--diff-filter=ACMR"],check=True,capture_output=True).stdout
+ return [os.fsdecode(p) for p in raw.split(b"\0") if p and is_approved_source(os.fsdecode(p))]
+
+def indexed_blob(path:str)->bytes:
+ entry=subprocess.run(["git","ls-files","-s","-z","--",path],check=True,capture_output=True).stdout.split(b"\0",1)[0]
+ if not entry:raise RuntimeError("staged_blob_missing")
+ fields=entry.split(b" ",2)
+ if len(fields)<3:raise RuntimeError("staged_blob_invalid")
+ return subprocess.run(["git","cat-file","blob",fields[1].decode("ascii")],check=True,capture_output=True).stdout
+
+def format_finding(finding:Finding,path:str|None=None)->str:
+ fields=["raw_privacy_violation"]
+ if path:fields.append(f"path={path}")
+ fields.extend((f"category={finding.category}",f"host={finding.host or 'unknown'}"))
+ if finding.key:fields.append(f"key={finding.key}")
+ return " ".join(fields)
+
+def check_staged()->int:
+ failed=False
+ for path in staged_source_paths():
+  try:text=indexed_blob(path).decode("utf-8")
+  except (UnicodeDecodeError,RuntimeError,subprocess.SubprocessError):
+   print(f"raw_privacy_violation path={path} category=unreadable_staged_blob host=unknown",file=sys.stderr);failed=True;continue
+  for finding in inspect_raw_privacy(text):print(format_finding(finding,path),file=sys.stderr);failed=True
+ return 1 if failed else 0
+
+def _repo_root()->Path:
+ raw=subprocess.run(["git","rev-parse","--show-toplevel"],check=True,capture_output=True).stdout
+ return Path(os.fsdecode(raw.rstrip(b"\n"))).resolve()
+
+def sanitize_paths(paths:list[str],check:bool=False)->int:
+ root=_repo_root();changed=False;failed=False
+ for supplied in paths:
+  candidate=Path(supplied) if Path(supplied).is_absolute() else root/supplied
+  if candidate.is_symlink():
+   print(f"raw_privacy_violation path={supplied} category=path_outside_approved_sources host=unknown",file=sys.stderr);failed=True;continue
+  try:candidate=candidate.resolve(strict=True);relative=candidate.relative_to(root)
+  except (OSError,ValueError):
+   print(f"raw_privacy_violation path={supplied} category=path_outside_approved_sources host=unknown",file=sys.stderr);failed=True;continue
+  rel=relative.as_posix()
+  if not is_approved_source(rel) or not candidate.is_file():
+   print(f"raw_privacy_violation path={rel} category=path_outside_approved_sources host=unknown",file=sys.stderr);failed=True;continue
+  try:prepared,categories=prepare_raw_source(candidate.read_text(encoding="utf-8"))
+  except RawPrivacyError as exc:
+   print(format_finding(exc.finding,rel),file=sys.stderr);failed=True;continue
+  original=candidate.read_text(encoding="utf-8")
+  if prepared!=original:
+   changed=True;print(f"raw_privacy_changed path={rel} categories={','.join(categories or ['format_normalized'])}")
+   if not check:
+    mode=candidate.stat().st_mode & 0o777
+    fd,tmp=tempfile.mkstemp(prefix=".tldr-raw-",dir=candidate.parent)
+    try:
+     with os.fdopen(fd,"w",encoding="utf-8",newline="") as handle:handle.write(prepared);handle.flush();os.fsync(handle.fileno())
+     os.chmod(tmp,mode);os.replace(tmp,candidate)
+    finally:
+     if os.path.exists(tmp):os.unlink(tmp)
+ return 1 if failed or (check and changed) else 0
+
+def main(argv:list[str]|None=None)->int:
+ parser=argparse.ArgumentParser(prog="python -m tools.tldr_raw_privacy");sub=parser.add_subparsers(dest="command",required=True)
+ sub.add_parser("check-staged")
+ sanitize=sub.add_parser("sanitize");sanitize.add_argument("--check",action="store_true");sanitize.add_argument("paths",nargs="+")
+ args=parser.parse_args(argv)
+ return check_staged() if args.command=="check-staged" else sanitize_paths(args.paths,args.check)
+
+if __name__=="__main__":raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a commit-boundary privacy gate for raw newsletter Markdown, prospective ingestion sanitation, and an explicit one-shot sanitizer for selected source paths.

## Production occurrence classification

Sanitized classification only:

- source: `TLDR/article_21-07-2026.md`
- host: `stratechery.com`
- key: `access_token`
- value length: 899 characters
- classification: authentication credential
- sensitivity: A — unambiguously sensitive
- present in the pending normalized issue: yes
- public canonical destination embedded in the URL path: yes

No parameter value, complete URL, reversible value hash, or surrounding source content is included here or in this branch.

## Enforcement boundary

`python -m tools.tldr_raw_privacy check-staged` obtains added/copied/modified/renamed paths through NUL-delimited staged Git diff output, restricts them to Markdown under `TLDR` or `TLDR *`, and reads each exact indexed blob through its Git object ID. It does not trust potentially different worktree bytes and does not impose a whole-corpus raw rewrite.

The gate rejects staged URL userinfo, known subscriber/account/management/unsubscribe/referral URLs, subscriber identity parameters, controlled credential keys, and the observed host/key category. Diagnostics contain only path, host, key, and category. `push_script.sh` invokes it after staging and immediately before every commit.

Prospective `script.py` ingestion now normalizes line endings and trailing whitespace, sanitizes known private URLs, canonicalizes the controlled observed case, and rejects unresolved credentials before writing. Rejected mail is not deleted from IMAP.

Explicit selected-file repair is available as:

```text
python -m tools.tldr_raw_privacy sanitize [--check] <path>...
```

It is deterministic, idempotent, atomic, explicit-path-only, and refuses symlinks and paths outside approved raw source directories.

## Changed files

- `tools/tldr_raw_privacy.py`
- `tools/tldr_derive/sanitizer.py`
- `script.py`
- `scripts/pipeline_lib.sh`
- `push_script.sh`
- `tests_derive/test_raw_privacy.py`
- `tests_pipeline/test_daily_pipeline.py`
- `docs/DAILY_PIPELINE.md`

No generated JSON, editorial artifact, image, environment file, credential, or production source blob is included.

## Tests

New coverage proves staged-index detection, index/worktree divergence, sanitized errors, NUL-safe paths with spaces, URL userinfo rejection, subscriber URL sanitation, observed host/key handling, preservation of ordinary and deliberately ambiguous public parameters, deterministic whitespace cleanup, idempotence, explicit sanitizer checks, symlink refusal, IMAP non-deletion on rejection, normalized re-derivation consistency, and pre-commit orchestration blocking.

Complete verification:

- derive/raw privacy: 60 passed
- pipeline: 24 passed
- deployment: 17 passed
- editorial: 73 passed
- Worker: 13 passed
- total: 187 passed
- Bash syntax: passed
- strict normalized privacy: 5,935 sources, zero errors, zero privacy hits
- normalized consistency: passed
- editorial consistency: passed

Production files were only NUL-safely unstaged. Their worktree hashes were preserved, protected editorial backups remain mode 0600, and all four production cron entries remain paused.
