### PR TITLE
Normalize mixed indentation in raw newsletters

### DIFF
--- a/tests_derive/test_raw_privacy.py
+++ b/tests_derive/test_raw_privacy.py
@@ -44,6 +44,9 @@ class RawPrivacyTests(unittest.TestCase):
   with self.assertRaises(RawPrivacyError):prepare_raw_source("https://example.com/private?api_key=DO_NOT_ECHO")
  def test_whitespace_normalization_is_deterministic_and_idempotent(self):
   raw="Header  \r\n\r\nArticle\t\r\n\r\n\r\n";once,_=prepare_raw_source(raw);twice,_=prepare_raw_source(once);self.assertEqual(once,"Header\n\nArticle\n");self.assertEqual(once,twice)
+ def test_mixed_leading_indentation_only_is_normalized(self):
+  raw=" \ttext\n  \t \ttext\n\ttext\ntext \t value\ntrailing \t\n";clean,_=prepare_raw_source(raw)
+  self.assertEqual(clean,"\ttext\n\t\ttext\n\ttext\ntext \t value\ntrailing\n");self.assertEqual(prepare_raw_source(clean)[0],clean)
  def test_explicit_sanitize_check_and_atomic_write(self):
   self.init_git();p=self.stage(text="Header  \n"+OBSERVED);before=p.read_bytes();out=io.StringIO()
   with contextlib.redirect_stdout(out):self.assertEqual(sanitize_paths([str(p)],check=True),1)
@@ -52,6 +55,11 @@ class RawPrivacyTests(unittest.TestCase):
   first=p.read_bytes()
   with contextlib.redirect_stdout(out):self.assertEqual(sanitize_paths([str(p)]),0)
   self.assertEqual(p.read_bytes(),first);self.assertIn(b"Header\n",first);self.assertNotIn("DO_NOT_ECHO",out.getvalue())
+ def test_sanitize_repairs_index_for_git_diff_check(self):
+  self.init_git();p=self.stage(text="# Header\n \titem\n  \t \titem\ntext \t value")
+  self.assertEqual(sanitize_paths([str(p)],check=True),1);self.assertEqual(sanitize_paths([str(p)]),0);self.git("add","--",str(p.relative_to(self.root)))
+  checked=subprocess.run(["git","diff","--cached","--check"],capture_output=True,text=True)
+  self.assertEqual(checked.returncode,0,msg=checked.stdout+checked.stderr);self.assertNotIn("DO_NOT_ECHO",checked.stdout+checked.stderr)
  def test_sanitize_refuses_symlink(self):
   self.init_git();target=self.root/"target.md";target.write_text("safe\n");link=self.root/"TLDR"/"link.md";link.parent.mkdir();link.symlink_to(target)
   err=io.StringIO()

--- a/tools/tldr_raw_privacy.py
+++ b/tools/tldr_raw_privacy.py
@@ -73,7 +73,12 @@ def prepare_raw_source(text:str)->tuple[str,list[str]]:
  def replace(match):
   replacement,found=_sanitize_url(match.group(0));categories.extend(found);return replacement
  text=_URL_RE.sub(replace,text)
- lines=[re.sub(r"[ \t]+$","",line) for line in text.split("\n")]
+ lines=[]
+ for line in text.split("\n"):
+  trailing_clean=re.sub(r"[ \t]+$","",line)
+  leading=re.match(r"[ \t]*",trailing_clean).group(0)
+  normalized_leading=re.sub(r" +(?=\t)","",leading)
+  lines.append(normalized_leading+trailing_clean[len(leading):])
  while lines and lines[-1]=="":lines.pop()
  return "\n".join(lines)+"\n",sorted(set(categories))
 


### PR DESCRIPTION
## Summary

Normalize only mixed leading indentation in prepared raw newsletters so staged sanitized sources pass Git's whitespace checks.

For each line, preparation still removes trailing spaces/tabs, then isolates the leading `[ \t]*` prefix and removes spaces immediately preceding tabs only within that prefix. Interior article text, URLs, ordinary tabs, Markdown content, and the existing privacy policy remain unchanged. The operation is deterministic and idempotent.

## Changed files

- `tools/tldr_raw_privacy.py`
- `tests_derive/test_raw_privacy.py`

No production newsletter, generated JSON, credential, image, editorial artifact, or environment file is included.

## Added regression coverage

Synthetic tests prove:

- a single space before a leading tab is removed;
- repeated mixed leading space/tab sequences are normalized;
- tabs not preceded by spaces are retained;
- interior `text <space><tab> value` content is retained byte-for-byte;
- trailing whitespace is still removed;
- repeated preparation is idempotent;
- `sanitize --check` detects required indentation repair;
- explicit sanitation repairs the file atomically;
- a repaired newsletter staged in a temporary real Git repository passes `git diff --cached --check`;
- existing sensitive-URL canonicalization remains green;
- deliberately permitted ambiguous public query parameters remain green;
- diagnostics contain no sensitive values.

## Verification

- derive: 46 passed
- raw privacy: 16 passed
- pipeline: 24 passed
- deployment: 17 passed
- editorial: 73 passed
- Worker: 13 passed
- total: 189 passed
- Bash syntax: passed
- strict normalized privacy: 5,935 sources, zero errors, zero privacy hits
- normalized consistency: passed
- editorial consistency: passed

Production's nine pending paths were only NUL-safely unstaged; their worktree hashes were preserved. All four production cron entries remain paused. No OpenRouter or R2 call occurred.
