### PR TITLE
Add a controlled illustration prompt calibration lab

### DIFF
--- a/docs/ILLUSTRATION_CALIBRATION.md
+++ b/docs/ILLUSTRATION_CALIBRATION.md
@@ -1,0 +1,88 @@
+# Illustration prompt calibration lab
+
+This lab compares immutable prompt profiles against one already validated Daily visual brief. It is isolated from normal publication: it never calls the editorial model, writes official editorial JSON, or uploads to R2. Production remains pinned to `baseline-v1` and the current `ILLUSTRATION_PROMPT_VERSION` until a separate winner-locking change is reviewed.
+
+Profiles are registered declaratively in `tools/tldr_editorial/illustration_prompts.py`. The calibration engine, safety policy, normalizer, gallery, and scoring format do not contain a profile count or list. Adding a direction requires registering another immutable profile; callers still explicitly choose profiles and cap the candidate count.
+
+## Profiles available initially
+
+- `baseline-v1`: byte-for-byte production direction.
+- `print-graphic-v1`: restricted-palette print/relief graphic.
+- `object-study-v1`: restrained, physically plausible object study.
+- `constructed-collage-v1`: tactile cut-paper editorial construction.
+- `ink-gouache-v1`: reduced ink and opaque-gouache drawing.
+- `cinematic-editorial-v1`: coherent, source-grounded cinematic framing and atmosphere.
+
+Only factual and safety restrictions are shared: no visible text, logos/trademarks, fabricated evidence, interfaces/screenshots, or imitation of named/living artists. Photorealism, concept art, detail, gradients, surfaces, and other aesthetic choices are profile-specific.
+
+## Safe usage
+
+Planning mode writes blind experiment files but makes zero network calls:
+
+```bash
+python -m tools.tldr_editorial calibrate-images \
+  --date 2026-07-21 \
+  --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
+  --output-dir /home/galois/tldr-image-calibration/round-1 \
+  --max-images 6
+```
+
+A live run is accepted only with both explicit acknowledgements:
+
+```bash
+python -m tools.tldr_editorial calibrate-images \
+  --date 2026-07-21 \
+  --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
+  --output-dir /home/galois/tldr-image-calibration/round-1 \
+  --require-live --acknowledge-cost --max-images 6
+```
+
+The output must be absolute, outside Git, non-symlinked, and empty. The checkout must be clean. CI live runs are forbidden. No candidate is automatically retried; after one failure, it and all unattempted candidates are recorded and paid calls stop.
+
+Outputs are `manifest.json`, private `blind-map.json`, `gallery.html`, `score-template.json`, and (live only) normalized anonymous WebPs. The gallery works through `file://`, randomizes anonymous candidates, uses identical framing, repeats identical source facts, and never includes profile IDs. Keep `blind-map.json` private until scoring is complete.
+
+## Human scoring rubric
+
+Score every criterion from 1 (poor) to 5 (excellent):
+
+| Weight | Criterion |
+|---:|---|
+| 30% | Absence of obvious AI visual clichés |
+| 20% | Sense of intentional editorial authorship |
+| 15% | Factual grounding and absence of invented detail |
+| 15% | Composition and immediate readability |
+| 10% | Fit with the TLDR Index newspaper design |
+| 10% | Readability at column/social-card size |
+
+Hard reject visible text/malformed lettering, logos/trademarks, invented evidence, generic neon/circuit-board/futuristic imagery, stock 3D-render aesthetics, incoherent geometry, unusable crops, or severe artifacts.
+
+For each image also record a one-sentence first impression, strongest quality, strongest weakness, whether it feels human-directed, and whether it should advance. Human judgment is authoritative; this version does not ask another model to score aesthetics.
+
+## Two-round protocol (documented, not executed here)
+
+### Round 1
+
+Use the existing AMD Helios visual brief. Generate one image for each explicitly selected registered profile (six for the initial registry), rank blindly, and retain two profiles. This is six paid image calls and zero editorial calls.
+
+### Round 2
+
+Select two additional validated briefs with different visual problems: one abstract software/model story and one human, organizational, or economic technology story. Generate both finalists against both briefs, then rank blindly. This is four paid image calls and zero editorial calls.
+
+The initial six-profile experiment therefore uses ten image calls total, zero editorial calls, no R2 uploads, and no official artifact mutation. Registry growth changes the total only when the operator explicitly selects added profiles and raises `--max-images`. A winner must perform well across all three story types; the AMD result alone cannot select production direction.
+
+## Later winner lock (not part of calibration)
+
+After human selection, a separate PR must:
+
+1. register the winner as `production-v2`;
+2. increment `ILLUSTRATION_PROMPT_VERSION`;
+3. update prompt-hash tests;
+4. merge through normal CI;
+5. perform one controlled live image regeneration for `2026-07-21`;
+6. reuse the resolved editorial plan and make zero editorial-model calls;
+7. generate exactly one replacement image;
+8. validate R2 and public delivery;
+9. prove a second invocation is a zero-call no-op;
+10. commit the new official artifact.
+
+The existing stale-illustration path must continue to reuse the resolved editorial plan when only the illustration prompt hash changes.

--- a/docs/ILLUSTRATION_CALIBRATION.md
+++ b/docs/ILLUSTRATION_CALIBRATION.md
@@ -24,7 +24,7 @@ python -m tools.tldr_editorial calibrate-images \
   --date 2026-07-21 \
   --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
   --output-dir /home/galois/tldr-image-calibration/round-1 \
-  --max-images 6
+  --samples-per-profile 2 --max-images 12
 ```
 
 A live run is accepted only with both explicit acknowledgements:
@@ -34,10 +34,11 @@ python -m tools.tldr_editorial calibrate-images \
   --date 2026-07-21 \
   --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
   --output-dir /home/galois/tldr-image-calibration/round-1 \
-  --require-live --acknowledge-cost --max-images 6
+  --samples-per-profile 2 \
+  --require-live --acknowledge-cost --max-images 12
 ```
 
-The output must be absolute, outside Git, non-symlinked, and empty. The checkout must be clean. CI live runs are forbidden. No candidate is automatically retried; after one failure, it and all unattempted candidates are recorded and paid calls stop.
+The output must be absolute, outside Git, non-symlinked, and empty. The checkout must be clean. CI live runs are forbidden. `--samples-per-profile` defaults to one and accepts one through five; the explicit `--max-images` ceiling applies to profiles multiplied by samples. Repeated samples receive independent anonymous IDs while using identical prompts and source facts. No candidate is automatically retried; after one failure, it and all unattempted candidates are recorded and paid calls stop.
 
 Outputs are `manifest.json`, private `blind-map.json`, `gallery.html`, `score-template.json`, and (live only) normalized anonymous WebPs. The gallery works through `file://`, randomizes anonymous candidates, uses identical framing, repeats identical source facts, and never includes profile IDs. Keep `blind-map.json` private until scoring is complete.
 
@@ -62,13 +63,13 @@ For each image also record a one-sentence first impression, strongest quality, s
 
 ### Round 1
 
-Use the existing AMD Helios visual brief. Generate one image for each explicitly selected registered profile (six for the initial registry), rank blindly, and retain two profiles. This is six paid image calls and zero editorial calls.
+Use the existing AMD Helios visual brief. Generate two independent anonymous samples for each of the six initial profiles, rank blindly on both quality and consistency, and retain two profiles. Both samples for a profile use the exact same prompt and facts. This is twelve paid image calls and zero editorial calls.
 
 ### Round 2
 
 Select two additional validated briefs with different visual problems: one abstract software/model story and one human, organizational, or economic technology story. Generate both finalists against both briefs, then rank blindly. This is four paid image calls and zero editorial calls.
 
-The initial six-profile experiment therefore uses ten image calls total, zero editorial calls, no R2 uploads, and no official artifact mutation. Registry growth changes the total only when the operator explicitly selects added profiles and raises `--max-images`. A winner must perform well across all three story types; the AMD result alone cannot select production direction.
+The initial repeated-sampling experiment therefore uses sixteen image calls total, zero editorial calls, no R2 uploads, and no official artifact mutation. Registry growth or sampling changes the total only when the operator explicitly selects profiles, chooses a sample count, and raises `--max-images`. A winner must perform well across all three story types; the AMD result alone cannot select production direction.
 
 ## Later winner lock (not part of calibration)
 

--- a/tests_editorial/test_illustration_calibration.py
+++ b/tests_editorial/test_illustration_calibration.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+import base64,hashlib,io,json,os,subprocess,tempfile,unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import patch
+from PIL import Image
+from tools.tldr_editorial.calibration import CalibrationContext,calibrate_images,run_calibration
+from tools.tldr_editorial.candidates import Candidate
+from tools.tldr_editorial.core import EditorialError
+from tools.tldr_editorial.image import assemble_prompt,decode_image,normalize_raster
+from tools.tldr_editorial.illustration_prompts import BASELINE_PREAMBLE,BASELINE_PROFILE,PROMPT_PROFILES,PromptProfile,SHARED_FACTUAL_RESTRICTIONS
+from tools.tldr_editorial.openrouter import Result
+from tests_editorial.helpers import config
+
+LEGACY="""Create a premium editorial illustration for a serious technology newspaper.
+
+The image is an editorial illustration, not documentary photography.
+Use one immediately readable focal subject.
+Use a strong, restrained composition with controlled contrast.
+Use sophisticated but understandable visual symbolism.
+Leave useful negative space around the focal subject.
+Do not render words, captions, headlines, logos, trademarks, interfaces, screenshots, charts, watermarks, or newspaper typography.
+Do not fabricate visible factual evidence.
+Do not imitate a named or living illustrator.
+Do not create a collage of unrelated news stories.
+The image must remain readable at newspaper-column and social-card sizes."""
+
+def candidate():return Candidate("c001","issue","article","tldr","NEWS","AMD Helios rack system","AMD introduced a rack-scale AI system with physically integrated compute and networking.","https://example.com/story","example.com",3,"editorial",(0,0))
+def context():return CalibrationContext("2026-07-21",{"mode":"lead_story","central_subject":"one rack-scale computing system","visual_metaphor":"industrial presence","composition":"single centered rack in a wide frame","forbidden_elements":["unsupported components"],"alt_text":"A rack-scale computing system"},(candidate(),))
+def png_value():
+ out=io.BytesIO();Image.new("RGB",(600,400),(80,90,100)).save(out,format="PNG");return base64.b64encode(out.getvalue()).decode()
+
+class ImageClient:
+ def __init__(self,fail=False):self.image_calls=0;self.editorial_calls=0;self.fail=fail
+ def editorial(self,*a):self.editorial_calls+=1;raise AssertionError("editorial called")
+ def image(self,prompt):
+  self.image_calls+=1
+  if self.fail:raise EditorialError("synthetic_image_failure")
+  return Result(png_value(),{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30,"cost_usd":0.125},None,"image/png")
+
+class CalibrationTests(unittest.TestCase):
+ def setUp(self):
+  self.old=Path.cwd();self.tmp=tempfile.TemporaryDirectory();self.base=Path(self.tmp.name);self.repo=self.base/"repo";self.repo.mkdir();os.chdir(self.repo)
+  subprocess.run(["git","init","-b","main"],check=True,capture_output=True);subprocess.run(["git","config","user.email","calibration@example.com"],check=True);subprocess.run(["git","config","user.name","Calibration Test"],check=True)
+  (self.repo/"tracked").write_text("clean\n");subprocess.run(["git","add","tracked"],check=True);subprocess.run(["git","commit","-m","fixture"],check=True,capture_output=True)
+ def tearDown(self):os.chdir(self.old);self.tmp.cleanup()
+ def output(self,name="output"):return self.base/name
+ def test_baseline_exactly_reproduces_legacy_production_prompt(self):
+  self.assertEqual(BASELINE_PREAMBLE,LEGACY);brief=context().brief;c=candidate()
+  expected=LEGACY+"\n\nSource stories (use only these facts):\nTitle: "+c.title+"\nSummary: "+c.summary+"\n\nCentral subject: "+brief["central_subject"]+"\nVisual metaphor: "+brief["visual_metaphor"]+"\nComposition: "+brief["composition"]+"\nForbidden elements: unsupported components\n"
+  self.assertEqual(assemble_prompt(brief,[c]),expected);self.assertEqual(assemble_prompt(brief,[c],BASELINE_PROFILE),expected)
+ def test_profiles_are_unique_frozen_declarative_and_share_only_safety_rules(self):
+  values=list(PROMPT_PROFILES.values());self.assertEqual(len({x.profile_id for x in values}),len(values));self.assertEqual(len({x.internal_id for x in values}),len(values))
+  self.assertTrue(all(x.shared_factual_restrictions==SHARED_FACTUAL_RESTRICTIONS for x in values));self.assertTrue(all(x.fixed_negative_constraints for x in values));self.assertFalse(any("photoreal" in x.lower() or "gradient" in x.lower() or "synthetic" in x.lower() for x in SHARED_FACTUAL_RESTRICTIONS))
+  with self.assertRaises(FrozenInstanceError):values[0].profile_id="changed"
+  with self.assertRaises(TypeError):PROMPT_PROFILES["new"]=values[0]
+ def test_prompt_assembly_is_deterministic_and_profiles_do_not_change_facts(self):
+  prompts=[assemble_prompt(context().brief,[candidate()],p) for p in PROMPT_PROFILES.values()]
+  self.assertEqual(prompts,[assemble_prompt(context().brief,[candidate()],p) for p in PROMPT_PROFILES.values()]);self.assertTrue(all(candidate().title in x and candidate().summary in x for x in prompts));self.assertGreater(len(set(prompts)),1)
+ def test_dry_default_has_zero_calls_and_never_writes_official_artifacts(self):
+  official=self.repo/"generated/editorial/manifest.json";official.parent.mkdir(parents=True);official.write_bytes(b"official\n");subprocess.run(["git","add","generated"],check=True);subprocess.run(["git","commit","-m","official"],check=True,capture_output=True)
+  client=ImageClient();result=calibrate_images(date=context().date,profile_ids=list(PROMPT_PROFILES),output_dir=self.output(),max_images=len(PROMPT_PROFILES),config=config(),client=client,context=context())
+  self.assertEqual((result["network_calls"],result["editorial_calls"],result["r2_calls"]),(0,0,0));self.assertEqual(client.image_calls,0);self.assertEqual(client.editorial_calls,0);self.assertEqual(official.read_bytes(),b"official\n")
+ def test_live_requires_both_flags_ci_is_forbidden_and_limit_is_enforced(self):
+  ids=["baseline-v1"]
+  for flags in ({"require_live":True},{"acknowledge_cost":True}):
+   with self.assertRaisesRegex(EditorialError,"calibration_live_flags_required"):calibrate_images(date=context().date,profile_ids=ids,output_dir=self.output("flags"+str(len(flags))),max_images=1,config=config(api_key="x"),context=context(),**flags)
+  with patch.dict(os.environ,{"CI":"true"}):
+   with self.assertRaisesRegex(EditorialError,"calibration_live_forbidden_in_ci"):calibrate_images(date=context().date,profile_ids=ids,output_dir=self.output("ci"),max_images=1,require_live=True,acknowledge_cost=True,config=config(api_key="x"),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_images(date=context().date,profile_ids=ids*2,output_dir=self.output("limit"),max_images=1,config=config(),context=context())
+ def test_output_inside_git_and_symlink_are_rejected(self):
+  with self.assertRaisesRegex(EditorialError,"calibration_output_inside_git"):calibrate_images(date=context().date,profile_ids=["baseline-v1"],output_dir=self.repo/"inside",max_images=1,config=config(),context=context())
+  target=self.output("target");target.mkdir();link=self.output("link");link.symlink_to(target,True)
+  with self.assertRaisesRegex(EditorialError,"calibration_output_symlink"):calibrate_images(date=context().date,profile_ids=["baseline-v1"],output_dir=link,max_images=1,config=config(),context=context())
+ def test_live_uses_image_only_no_r2_and_persists_cost_hash_and_production_webp(self):
+  client=ImageClient();out=self.output();tracked=[];real=tempfile.mkstemp
+  def recording(*args,**kwargs):
+   fd,path=real(*args,**kwargs)
+   if kwargs.get("prefix",args[0] if args else "").startswith("tldr-calibration-provider-"):tracked.append(path)
+   return fd,path
+  with patch.dict(os.environ,{"CI":""}),patch("tools.tldr_editorial.calibration.tempfile.mkstemp",side_effect=recording),patch("tools.tldr_editorial.r2_storage.R2Storage",side_effect=AssertionError("R2 called")) as r2:
+   result=calibrate_images(date=context().date,profile_ids=["print-graphic-v1"],output_dir=out,max_images=1,require_live=True,acknowledge_cost=True,config=config(api_key="x"),client=client,context=context())
+  self.assertTrue(result["success"]);self.assertEqual((client.image_calls,client.editorial_calls),(1,0));self.assertEqual(result["r2_calls"],0);r2.assert_not_called();self.assertTrue(tracked);self.assertTrue(all(not Path(x).exists() for x in tracked))
+  manifest=json.loads((out/"manifest.json").read_text());record=manifest["candidates"][0];self.assertEqual(record["usage"]["cost_usd"],0.125);data=(out/record["image_file"]).read_bytes();self.assertEqual(record["sha256"],"sha256:"+hashlib.sha256(data).hexdigest())
+  raw,media=decode_image(png_value(),"image/png");source=self.output("source.raster");source.write_bytes(raw);expected=normalize_raster(source,media,config().max_provider_image_bytes,config().max_image_pixels,config().max_image_bytes);self.assertEqual(data,expected.data)
+ def test_blind_gallery_hides_profiles_and_mapping_sets_match(self):
+  out=self.output();calibrate_images(date=context().date,profile_ids=list(PROMPT_PROFILES),output_dir=out,max_images=len(PROMPT_PROFILES),config=config(),context=context())
+  manifest=json.loads((out/"manifest.json").read_text());mapping=json.loads((out/"blind-map.json").read_text())["mapping"];gallery=(out/"gallery.html").read_text();score=json.loads((out/"score-template.json").read_text())
+  candidate_ids={x["candidate_id"] for x in manifest["candidates"]};self.assertEqual(candidate_ids,set(mapping));self.assertEqual(candidate_ids,{x["candidate_id"] for x in score["scores"]})
+  self.assertTrue(all(profile not in gallery for profile in PROMPT_PROFILES));self.assertTrue(all(x in gallery for x in candidate_ids));self.assertTrue(all(candidate().title in card for card in [gallery]));self.assertEqual((out/"blind-map.json").stat().st_mode&0o777,0o600)
+ def test_failure_is_recorded_once_and_stops_paid_candidates(self):
+  out=self.output();client=ImageClient(fail=True);ids=list(PROMPT_PROFILES)[:3]
+  with patch.dict(os.environ,{"CI":""}):result=calibrate_images(date=context().date,profile_ids=ids,output_dir=out,max_images=3,require_live=True,acknowledge_cost=True,config=config(api_key="x"),client=client,context=context())
+  self.assertFalse(result["success"]);self.assertEqual(client.image_calls,1);records=json.loads((out/"manifest.json").read_text())["candidates"];self.assertEqual(sum(x["status"]=="failed" for x in records),1);self.assertEqual(sum(x["status"]=="not_attempted" for x in records),2);self.assertNotIn("request_id",json.dumps(records))
+ def test_custom_registered_shape_needs_no_engine_count_change(self):
+  out=self.output();out.mkdir();custom=PromptProfile("future-v1","profile-999","Future profile preamble",SHARED_FACTUAL_RESTRICTIONS,())
+  result=run_calibration(context=context(),profiles=[custom],output=out,cfg=config(),live=False);self.assertEqual(result["candidate_count"],1);self.assertEqual(result["network_calls"],0)
+
+if __name__=="__main__":unittest.main()

--- a/tests_editorial/test_illustration_calibration.py
+++ b/tests_editorial/test_illustration_calibration.py
@@ -61,13 +61,27 @@ class CalibrationTests(unittest.TestCase):
   official=self.repo/"generated/editorial/manifest.json";official.parent.mkdir(parents=True);official.write_bytes(b"official\n");subprocess.run(["git","add","generated"],check=True);subprocess.run(["git","commit","-m","official"],check=True,capture_output=True)
   client=ImageClient();result=calibrate_images(date=context().date,profile_ids=list(PROMPT_PROFILES),output_dir=self.output(),max_images=len(PROMPT_PROFILES),config=config(),client=client,context=context())
   self.assertEqual((result["network_calls"],result["editorial_calls"],result["r2_calls"]),(0,0,0));self.assertEqual(client.image_calls,0);self.assertEqual(client.editorial_calls,0);self.assertEqual(official.read_bytes(),b"official\n")
+ def test_default_one_sample_per_profile(self):
+  out=self.output();selected=list(PROMPT_PROFILES)[:2];result=calibrate_images(date=context().date,profile_ids=selected,output_dir=out,max_images=2,config=config(),context=context())
+  mapping=json.loads((out/"blind-map.json").read_text())["mapping"];self.assertEqual(result["candidate_count"],2);self.assertEqual({x["sample_index"] for x in mapping.values()},{1});self.assertEqual({x["profile_id"] for x in mapping.values()},set(selected))
+ def test_two_samples_are_anonymous_complete_and_use_identical_profile_prompts(self):
+  out=self.output();selected=list(PROMPT_PROFILES)[:2];client=ImageClient();result=calibrate_images(date=context().date,profile_ids=selected,output_dir=out,max_images=4,samples_per_profile=2,config=config(),client=client,context=context())
+  manifest=json.loads((out/"manifest.json").read_text());mapping=json.loads((out/"blind-map.json").read_text())["mapping"];gallery=(out/"gallery.html").read_text();ids=[x["candidate_id"] for x in manifest["candidates"]]
+  self.assertEqual(result["candidate_count"],4);self.assertEqual(len(ids),len(set(ids)));self.assertEqual(set(ids),set(mapping));self.assertEqual(client.image_calls,0)
+  for profile_id in selected:
+   members={candidate_id for candidate_id,value in mapping.items() if value=={"profile_id":profile_id,"sample_index":1} or value=={"profile_id":profile_id,"sample_index":2}}
+   self.assertEqual(len(members),2);self.assertEqual(len({x["prompt_sha256"] for x in manifest["candidates"] if x["candidate_id"] in members}),1)
+  self.assertTrue(all(profile_id not in gallery and profile_id not in (out/"manifest.json").read_text() for profile_id in selected));self.assertNotIn("sample_index",gallery);self.assertNotIn("sample_index",(out/"manifest.json").read_text())
  def test_live_requires_both_flags_ci_is_forbidden_and_limit_is_enforced(self):
   ids=["baseline-v1"]
   for flags in ({"require_live":True},{"acknowledge_cost":True}):
    with self.assertRaisesRegex(EditorialError,"calibration_live_flags_required"):calibrate_images(date=context().date,profile_ids=ids,output_dir=self.output("flags"+str(len(flags))),max_images=1,config=config(api_key="x"),context=context(),**flags)
   with patch.dict(os.environ,{"CI":"true"}):
    with self.assertRaisesRegex(EditorialError,"calibration_live_forbidden_in_ci"):calibrate_images(date=context().date,profile_ids=ids,output_dir=self.output("ci"),max_images=1,require_live=True,acknowledge_cost=True,config=config(api_key="x"),context=context())
-  with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_images(date=context().date,profile_ids=ids*2,output_dir=self.output("limit"),max_images=1,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_images(date=context().date,profile_ids=["baseline-v1","print-graphic-v1"],output_dir=self.output("limit"),max_images=3,samples_per_profile=2,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_duplicate_profile"):calibrate_images(date=context().date,profile_ids=ids*2,output_dir=self.output("duplicate"),max_images=2,config=config(),context=context())
+  for value in (0,6):
+   with self.assertRaisesRegex(EditorialError,"calibration_samples_per_profile_invalid"):calibrate_images(date=context().date,profile_ids=ids,output_dir=self.output("samples"+str(value)),max_images=10,samples_per_profile=value,config=config(),context=context())
  def test_output_inside_git_and_symlink_are_rejected(self):
   with self.assertRaisesRegex(EditorialError,"calibration_output_inside_git"):calibrate_images(date=context().date,profile_ids=["baseline-v1"],output_dir=self.repo/"inside",max_images=1,config=config(),context=context())
   target=self.output("target");target.mkdir();link=self.output("link");link.symlink_to(target,True)
@@ -90,8 +104,8 @@ class CalibrationTests(unittest.TestCase):
   self.assertTrue(all(profile not in gallery for profile in PROMPT_PROFILES));self.assertTrue(all(x in gallery for x in candidate_ids));self.assertTrue(all(candidate().title in card for card in [gallery]));self.assertEqual((out/"blind-map.json").stat().st_mode&0o777,0o600)
  def test_failure_is_recorded_once_and_stops_paid_candidates(self):
   out=self.output();client=ImageClient(fail=True);ids=list(PROMPT_PROFILES)[:3]
-  with patch.dict(os.environ,{"CI":""}):result=calibrate_images(date=context().date,profile_ids=ids,output_dir=out,max_images=3,require_live=True,acknowledge_cost=True,config=config(api_key="x"),client=client,context=context())
-  self.assertFalse(result["success"]);self.assertEqual(client.image_calls,1);records=json.loads((out/"manifest.json").read_text())["candidates"];self.assertEqual(sum(x["status"]=="failed" for x in records),1);self.assertEqual(sum(x["status"]=="not_attempted" for x in records),2);self.assertNotIn("request_id",json.dumps(records))
+  with patch.dict(os.environ,{"CI":""}):result=calibrate_images(date=context().date,profile_ids=ids,output_dir=out,max_images=6,samples_per_profile=2,require_live=True,acknowledge_cost=True,config=config(api_key="x"),client=client,context=context())
+  self.assertFalse(result["success"]);self.assertEqual(client.image_calls,1);records=json.loads((out/"manifest.json").read_text())["candidates"];self.assertEqual(sum(x["status"]=="failed" for x in records),1);self.assertEqual(sum(x["status"]=="not_attempted" for x in records),5);self.assertNotIn("request_id",json.dumps(records))
  def test_custom_registered_shape_needs_no_engine_count_change(self):
   out=self.output();out.mkdir();custom=PromptProfile("future-v1","profile-999","Future profile preamble",SHARED_FACTUAL_RESTRICTIONS,())
   result=run_calibration(context=context(),profiles=[custom],output=out,cfg=config(),live=False);self.assertEqual(result["candidate_count"],1);self.assertEqual(result["network_calls"],0)

--- a/tools/tldr_editorial/calibration.py
+++ b/tools/tldr_editorial/calibration.py
@@ -1,0 +1,150 @@
+"""Isolated, human-scored illustration prompt calibration lab."""
+from __future__ import annotations
+import hashlib,html,json,os,secrets,subprocess,tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+from .artifacts import load_artifact,validate_all
+from .candidates import Candidate,load_date
+from .config import Config
+from .core import EditorialError
+from .image import assemble_prompt,decode_image,normalize_raster
+from .illustration_prompts import PROFILE_SCHEMA_VERSION,PromptProfile,get_profile
+from .openrouter import OpenRouterClient
+
+CALIBRATION_SCHEMA_VERSION="1.0.0"
+RUBRIC={
+ "scale":{"minimum":1,"maximum":5},
+ "weighted_criteria":[
+  {"id":"absence_of_ai_cliches","weight":0.30,"label":"Absence of obvious AI visual clichés"},
+  {"id":"editorial_authorship","weight":0.20,"label":"Sense of intentional editorial authorship"},
+  {"id":"factual_grounding","weight":0.15,"label":"Factual grounding and absence of invented detail"},
+  {"id":"composition","weight":0.15,"label":"Composition and immediate readability"},
+  {"id":"newspaper_fit","weight":0.10,"label":"Fit with the TLDR Index newspaper design"},
+  {"id":"small_size_readability","weight":0.10,"label":"Readability at column/social-card size"},
+ ],
+ "hard_rejections":["visible text or malformed lettering","logos or trademarks","invented factual evidence","generic neon/circuit-board/futuristic imagery","obvious stock 3D render aesthetics","incoherent object geometry","unusable crop","severe visual artifacts"],
+ "notes":["first_impression","strongest_quality","strongest_weakness","feels_human_directed","advance_to_round_two"],
+}
+
+@dataclass(frozen=True)
+class CalibrationContext:
+ date:str
+ brief:dict
+ sources:tuple[Candidate,...]
+
+def _git_root()->Path:
+ try:raw=subprocess.run(["git","rev-parse","--show-toplevel"],check=True,capture_output=True,timeout=10).stdout
+ except (OSError,subprocess.SubprocessError) as exc:raise EditorialError("calibration_git_root_failed") from exc
+ return Path(os.fsdecode(raw.rstrip(b"\n"))).resolve()
+
+def _require_clean()->None:
+ try:raw=subprocess.run(["git","status","--porcelain=v1","-z","--untracked-files=all"],check=True,capture_output=True,timeout=10).stdout
+ except (OSError,subprocess.SubprocessError) as exc:raise EditorialError("calibration_git_status_failed") from exc
+ if raw:raise EditorialError("calibration_git_workspace_not_clean")
+
+def _prepare_output(output:Path,root:Path)->Path:
+ if not output.is_absolute():raise EditorialError("calibration_output_must_be_absolute")
+ if output.is_symlink():raise EditorialError("calibration_output_symlink")
+ try:parent=output.parent.resolve(strict=True)
+ except OSError as exc:raise EditorialError("calibration_output_parent_invalid") from exc
+ candidate=parent/output.name
+ try:candidate.relative_to(root)
+ except ValueError:pass
+ else:raise EditorialError("calibration_output_inside_git")
+ if candidate.exists():
+  if candidate.is_symlink() or not candidate.is_dir():raise EditorialError("calibration_output_invalid")
+  if any(candidate.iterdir()):raise EditorialError("calibration_output_not_empty")
+ else:candidate.mkdir(mode=0o700)
+ os.chmod(candidate,0o700)
+ return candidate
+
+def _context(date:str,generated:Path,editorial_output:Path,cfg:Config)->CalibrationContext:
+ errors=validate_all(editorial_output,generated,None,cfg.r2_public_base_url,cfg.max_candidates,cfg.editorial_model,cfg.image_model,cfg.max_provider_image_bytes,cfg.max_image_pixels,cfg.max_image_bytes)
+ if errors:raise EditorialError("calibration_official_artifact_invalid")
+ artifact=load_artifact(editorial_output,date)
+ if not artifact:raise EditorialError("calibration_artifact_missing")
+ brief=artifact.get("plan",{}).get("visual_brief",{})
+ if brief.get("mode")=="none":raise EditorialError("calibration_visual_brief_missing")
+ by={(c.issue_id,c.article_id):c for c in load_date(generated,date)}
+ try:sources=tuple(by[(x["issue_id"],x["article_id"])] for x in brief["sources"])
+ except (KeyError,TypeError) as exc:raise EditorialError("calibration_source_reference_invalid") from exc
+ if not sources:raise EditorialError("calibration_source_reference_invalid")
+ prompt_brief={k:brief[k] for k in ("mode","central_subject","visual_metaphor","composition","forbidden_elements","alt_text")}
+ return CalibrationContext(date,prompt_brief,sources)
+
+def _atomic_bytes(path:Path,data:bytes,mode:int=0o600)->None:
+ fd,tmp=tempfile.mkstemp(prefix=".calibration-",dir=path.parent)
+ try:
+  os.fchmod(fd,mode)
+  with os.fdopen(fd,"wb") as handle:handle.write(data);handle.flush();os.fsync(handle.fileno())
+  os.replace(tmp,path)
+ finally:
+  try:os.unlink(tmp)
+  except FileNotFoundError:pass
+
+def _json(path:Path,value:dict,mode:int=0o600)->None:_atomic_bytes(path,(json.dumps(value,ensure_ascii=False,sort_keys=True,indent=2)+"\n").encode(),mode)
+
+def _gallery(candidates:list[dict],context:CalibrationContext)->str:
+ source="".join(f"<p><strong>{html.escape(c.title)}</strong><br>{html.escape(c.summary)}</p>" for c in context.sources)
+ cards=[]
+ for c in candidates:
+  media=f'<img src="{html.escape(c["image_file"])}" alt="Anonymous calibration candidate">' if c.get("image_file") else '<div class="placeholder">No image generated</div>'
+  cards.append(f'<article><h2>{html.escape(c["candidate_id"])}</h2>{media}<div class="source">{source}</div></article>')
+ return """<!doctype html><meta charset="utf-8"><title>Blind illustration calibration</title>
+<style>body{font:16px system-ui;margin:2rem;background:#eee;color:#111}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:2rem}article{background:white;padding:1rem}img,.placeholder{display:block;width:100%;aspect-ratio:3/2;object-fit:cover;background:#ddd}.placeholder{display:grid;place-items:center}.source{font-size:.9rem}h2{font-size:1rem}</style>
+<h1>Blind illustration calibration</h1><div class="grid">"""+"".join(cards)+"</div>\n"
+
+def _write_outputs(output:Path,context:CalibrationContext,candidates:list[dict],mapping:dict)->None:
+ order=list(candidates);secrets.SystemRandom().shuffle(order)
+ manifest={"schema_version":CALIBRATION_SCHEMA_VERSION,"profile_schema_version":PROFILE_SCHEMA_VERSION,"date":context.date,"model":next((x["model"] for x in candidates),None),"source_context":[{"issue_id":c.issue_id,"article_id":c.article_id,"title":c.title,"summary":c.summary} for c in context.sources],"candidates":order}
+ blind={"schema_version":CALIBRATION_SCHEMA_VERSION,"mapping":mapping}
+ score={"schema_version":CALIBRATION_SCHEMA_VERSION,"rubric":RUBRIC,"scores":[{"candidate_id":x["candidate_id"],"hard_rejection":False,"hard_rejection_reasons":[],"ratings":{c["id"]:None for c in RUBRIC["weighted_criteria"]},"first_impression":"","strongest_quality":"","strongest_weakness":"","feels_human_directed":None,"advance_to_round_two":None} for x in order]}
+ _json(output/"manifest.json",manifest);_json(output/"blind-map.json",blind);_json(output/"score-template.json",score)
+ _atomic_bytes(output/"gallery.html",_gallery(order,context).encode(),0o600)
+
+def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile],output:Path,cfg:Config,live:bool,client=None)->dict:
+ ids=[]
+ for _ in profiles:
+  while True:
+   value="candidate-"+secrets.token_hex(4)
+   if value not in ids:ids.append(value);break
+ mapping={candidate:profile.profile_id for candidate,profile in zip(ids,profiles)};records=[];failed=False;network_calls=0;image_client=(client or OpenRouterClient(cfg)) if live else None
+ for index,(candidate_id,profile) in enumerate(zip(ids,profiles)):
+  prompt=assemble_prompt(context.brief,list(context.sources),profile);prompt_sha="sha256:"+hashlib.sha256(prompt.encode()).hexdigest()
+  record={"candidate_id":candidate_id,"status":"planned" if not live else "not_attempted","image_file":None,"sha256":None,"width":None,"height":None,"bytes":None,"prompt_sha256":prompt_sha,"model":cfg.image_model,"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"cost_usd":0.0},"source_references":[{"issue_id":c.issue_id,"article_id":c.article_id} for c in context.sources]}
+  records.append(record)
+  if not live or failed:continue
+  try:
+   network_calls+=1;result=image_client.image(prompt)
+   raw,media=decode_image(result.value,result.media_type)
+   fd,tmp=tempfile.mkstemp(prefix="tldr-calibration-provider-",suffix=".raster")
+   try:
+    os.fchmod(fd,0o600)
+    with os.fdopen(fd,"wb") as handle:handle.write(raw);handle.flush();os.fsync(handle.fileno())
+    image=normalize_raster(Path(tmp),media,cfg.max_provider_image_bytes,cfg.max_image_pixels,cfg.max_image_bytes)
+   finally:
+    try:os.unlink(tmp)
+    except FileNotFoundError:pass
+   filename=candidate_id+".webp";_atomic_bytes(output/filename,image.data)
+   record.update(status="ready",image_file=filename,sha256=image.sha256,width=image.width,height=image.height,bytes=image.bytes,usage=result.usage)
+  except EditorialError as exc:
+   record.update(status="failed",failure_category=str(exc));failed=True
+ _write_outputs(output,context,records,mapping)
+ return {"date":context.date,"candidate_count":len(records),"ready_count":sum(x["status"]=="ready" for x in records),"failed_count":sum(x["status"]=="failed" for x in records),"network_calls":network_calls,"editorial_calls":0,"r2_calls":0,"live":live,"success":not failed,"output_dir":str(output)}
+
+def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_images:int,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
+ if not date:raise EditorialError("calibration_date_required")
+ if not profile_ids:raise EditorialError("calibration_profiles_required")
+ if max_images<1 or len(profile_ids)>max_images:raise EditorialError("calibration_image_limit")
+ if len(set(profile_ids))!=len(profile_ids):raise EditorialError("calibration_duplicate_profile")
+ try:profiles=[get_profile(x) for x in profile_ids]
+ except KeyError as exc:raise EditorialError("calibration_profile_unknown") from exc
+ if require_live!=acknowledge_cost:raise EditorialError("calibration_live_flags_required")
+ live=require_live and acknowledge_cost
+ if live and os.getenv("CI"):raise EditorialError("calibration_live_forbidden_in_ci")
+ _require_clean();root=_git_root();output=_prepare_output(output_dir,root);cfg=config or Config.from_env()
+ if live:cfg.require_openrouter()
+ context=context or _context(date,generated,editorial_output,cfg)
+ if context.date!=date:raise EditorialError("calibration_context_date_mismatch")
+ return run_calibration(context=context,profiles=profiles,output=output,cfg=cfg,live=live,client=client)

--- a/tools/tldr_editorial/calibration.py
+++ b/tools/tldr_editorial/calibration.py
@@ -103,14 +103,15 @@ def _write_outputs(output:Path,context:CalibrationContext,candidates:list[dict],
  _json(output/"manifest.json",manifest);_json(output/"blind-map.json",blind);_json(output/"score-template.json",score)
  _atomic_bytes(output/"gallery.html",_gallery(order,context).encode(),0o600)
 
-def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile],output:Path,cfg:Config,live:bool,client=None)->dict:
- ids=[]
- for _ in profiles:
+def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile],output:Path,cfg:Config,live:bool,client=None,samples_per_profile:int=1)->dict:
+ if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
+ assignments=[(profile,sample_index) for profile in profiles for sample_index in range(1,samples_per_profile+1)];ids=[]
+ for _ in assignments:
   while True:
    value="candidate-"+secrets.token_hex(4)
    if value not in ids:ids.append(value);break
- mapping={candidate:profile.profile_id for candidate,profile in zip(ids,profiles)};records=[];failed=False;network_calls=0;image_client=(client or OpenRouterClient(cfg)) if live else None
- for index,(candidate_id,profile) in enumerate(zip(ids,profiles)):
+ mapping={candidate:{"profile_id":profile.profile_id,"sample_index":sample_index} for candidate,(profile,sample_index) in zip(ids,assignments)};records=[];failed=False;network_calls=0;image_client=(client or OpenRouterClient(cfg)) if live else None
+ for candidate_id,(profile,sample_index) in zip(ids,assignments):
   prompt=assemble_prompt(context.brief,list(context.sources),profile);prompt_sha="sha256:"+hashlib.sha256(prompt.encode()).hexdigest()
   record={"candidate_id":candidate_id,"status":"planned" if not live else "not_attempted","image_file":None,"sha256":None,"width":None,"height":None,"bytes":None,"prompt_sha256":prompt_sha,"model":cfg.image_model,"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"cost_usd":0.0},"source_references":[{"issue_id":c.issue_id,"article_id":c.article_id} for c in context.sources]}
   records.append(record)
@@ -133,10 +134,12 @@ def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile
  _write_outputs(output,context,records,mapping)
  return {"date":context.date,"candidate_count":len(records),"ready_count":sum(x["status"]=="ready" for x in records),"failed_count":sum(x["status"]=="failed" for x in records),"network_calls":network_calls,"editorial_calls":0,"r2_calls":0,"live":live,"success":not failed,"output_dir":str(output)}
 
-def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_images:int,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
+def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_images:int,samples_per_profile:int=1,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
  if not date:raise EditorialError("calibration_date_required")
  if not profile_ids:raise EditorialError("calibration_profiles_required")
- if max_images<1 or len(profile_ids)>max_images:raise EditorialError("calibration_image_limit")
+ if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
+ total=len(profile_ids)*samples_per_profile
+ if max_images<1 or total>max_images:raise EditorialError("calibration_image_limit")
  if len(set(profile_ids))!=len(profile_ids):raise EditorialError("calibration_duplicate_profile")
  try:profiles=[get_profile(x) for x in profile_ids]
  except KeyError as exc:raise EditorialError("calibration_profile_unknown") from exc
@@ -147,4 +150,4 @@ def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_im
  if live:cfg.require_openrouter()
  context=context or _context(date,generated,editorial_output,cfg)
  if context.date!=date:raise EditorialError("calibration_context_date_mismatch")
- return run_calibration(context=context,profiles=profiles,output=output,cfg=cfg,live=live,client=client)
+ return run_calibration(context=context,profiles=profiles,output=output,cfg=cfg,live=live,client=client,samples_per_profile=samples_per_profile)

--- a/tools/tldr_editorial/cli.py
+++ b/tools/tldr_editorial/cli.py
@@ -16,7 +16,7 @@ def parser():
     for x in ("force","retry-image","dry-run","offline","require-live"): g.add_argument("--"+x,action="store_true")
     v=sub.add_parser("validate"); v.add_argument("--all",action="store_true",required=True); v.add_argument("--output",type=Path,default=Path("generated/editorial")); v.add_argument("--generated",type=Path,default=Path("generated")); v.add_argument("--verify-storage",action="store_true")
     s=sub.add_parser("storage-report"); s.add_argument("--output",type=Path,default=Path("generated/editorial")); s.add_argument("--list-r2",action="store_true")
-    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);c.add_argument("--profiles",required=True);c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
+    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);c.add_argument("--profiles",required=True);c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);c.add_argument("--samples-per-profile",type=int,default=1);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
     return p
 
 def main(argv=None):
@@ -27,7 +27,7 @@ def main(argv=None):
             print(json.dumps(result,sort_keys=True)); return 0
         if a.command=="calibrate-images":
             ids=[x.strip() for x in a.profiles.split(",") if x.strip()]
-            result=calibrate_images(date=a.date,profile_ids=ids,output_dir=a.output_dir,max_images=a.max_images,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
+            result=calibrate_images(date=a.date,profile_ids=ids,output_dir=a.output_dir,max_images=a.max_images,samples_per_profile=a.samples_per_profile,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
             print(json.dumps(result,sort_keys=True));return 0 if result["success"] else 1
         if a.command=="validate":
             cfg=Config.from_env(); storage=R2Storage(cfg) if a.verify_storage else None

--- a/tools/tldr_editorial/cli.py
+++ b/tools/tldr_editorial/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import argparse,json,sys
 from pathlib import Path
 from .artifacts import validate_all
+from .calibration import calibrate_images
 from .config import Config
 from .core import EditorialError
 from .generator import generate
@@ -15,6 +16,7 @@ def parser():
     for x in ("force","retry-image","dry-run","offline","require-live"): g.add_argument("--"+x,action="store_true")
     v=sub.add_parser("validate"); v.add_argument("--all",action="store_true",required=True); v.add_argument("--output",type=Path,default=Path("generated/editorial")); v.add_argument("--generated",type=Path,default=Path("generated")); v.add_argument("--verify-storage",action="store_true")
     s=sub.add_parser("storage-report"); s.add_argument("--output",type=Path,default=Path("generated/editorial")); s.add_argument("--list-r2",action="store_true")
+    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);c.add_argument("--profiles",required=True);c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
     return p
 
 def main(argv=None):
@@ -23,6 +25,10 @@ def main(argv=None):
         if a.command=="generate":
             result=generate(generated=a.generated,output=a.output,date=a.date,latest=a.latest or not a.date,offline=a.offline,dry_run=a.dry_run,require_live=a.require_live,force=a.force,retry_image=a.retry_image)
             print(json.dumps(result,sort_keys=True)); return 0
+        if a.command=="calibrate-images":
+            ids=[x.strip() for x in a.profiles.split(",") if x.strip()]
+            result=calibrate_images(date=a.date,profile_ids=ids,output_dir=a.output_dir,max_images=a.max_images,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
+            print(json.dumps(result,sort_keys=True));return 0 if result["success"] else 1
         if a.command=="validate":
             cfg=Config.from_env(); storage=R2Storage(cfg) if a.verify_storage else None
             errors=validate_all(a.output,a.generated,storage,cfg.r2_public_base_url,cfg.max_candidates,cfg.editorial_model,cfg.image_model,cfg.max_provider_image_bytes,cfg.max_image_pixels,cfg.max_image_bytes)

--- a/tools/tldr_editorial/illustration_prompts.py
+++ b/tools/tldr_editorial/illustration_prompts.py
@@ -1,0 +1,79 @@
+"""Immutable, versioned illustration prompt profiles.
+
+Production intentionally remains pinned to ``baseline-v1``. Profile registration is
+data-driven; calibration code does not know or special-case the registered IDs.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+PROFILE_SCHEMA_VERSION="1.0.0"
+SHARED_FACTUAL_RESTRICTIONS=(
+ "Do not render visible text, captions, headlines, or newspaper typography.",
+ "Do not render logos or trademarks.",
+ "Do not fabricate visible factual evidence.",
+ "Do not render interfaces or screenshots.",
+ "Do not imitate a named or living artist.",
+)
+
+@dataclass(frozen=True)
+class PromptProfile:
+ profile_id:str
+ internal_id:str
+ preamble:str
+ fixed_negative_constraints:tuple[str,...]
+ rendering_material_constraints:tuple[str,...]
+ shared_factual_restrictions:tuple[str,...]=SHARED_FACTUAL_RESTRICTIONS
+ schema_version:str=PROFILE_SCHEMA_VERSION
+
+# Byte-for-byte legacy production preamble. Do not edit without the later
+# production-profile selection and prompt-version migration.
+BASELINE_PREAMBLE="""Create a premium editorial illustration for a serious technology newspaper.
+
+The image is an editorial illustration, not documentary photography.
+Use one immediately readable focal subject.
+Use a strong, restrained composition with controlled contrast.
+Use sophisticated but understandable visual symbolism.
+Leave useful negative space around the focal subject.
+Do not render words, captions, headlines, logos, trademarks, interfaces, screenshots, charts, watermarks, or newspaper typography.
+Do not fabricate visible factual evidence.
+Do not imitate a named or living illustrator.
+Do not create a collage of unrelated news stories.
+The image must remain readable at newspaper-column and social-card sizes."""
+
+def _preamble(direction:tuple[str,...],negative:tuple[str,...],materials:tuple[str,...]=())->str:
+ sections=["Create an authored editorial illustration for a serious technology newspaper.","","Direction:"]
+ sections.extend(f"- {x}" for x in direction)
+ if materials:sections.extend(("","Rendering and material constraints:",*(f"- {x}" for x in materials)))
+ sections.extend(("","Fixed factual and safety restrictions:",*(f"- {x}" for x in SHARED_FACTUAL_RESTRICTIONS),"","Profile-specific exclusions:",*(f"- {x}" for x in negative)))
+ return "\n".join(sections)
+
+def _profile(profile_id:str,internal_id:str,direction:tuple[str,...],negative:tuple[str,...],materials:tuple[str,...]=())->PromptProfile:
+ return PromptProfile(profile_id,internal_id,_preamble(direction,negative,materials),negative,materials)
+
+_REGISTERED=(
+ PromptProfile("baseline-v1","profile-001",BASELINE_PREAMBLE,("not documentary photography","no collage of unrelated news stories"),()),
+ _profile("print-graphic-v1","profile-002",(
+  "serious newspaper print illustration","flat, deliberate shapes","restricted palette of approximately three to five colors","subtle paper grain","screen-print or relief-print material character","simplified but accurate geometry","visible authored decisions","no photorealism"),(
+  "glossy 3D rendering","neon glows","blue/orange cinematic gradients","translucent holographic layers","floating particles","circuit-board decoration","volumetric light","synthetic chrome","generic futuristic environments","excessive detail")),
+ _profile("object-study-v1","profile-003",(
+  "one precise editorial object study","physically plausible materials and proportions","calm neutral lighting","restrained background","emphasis on silhouette, scale, construction, and industrial presence","visual interest through framing rather than fantasy symbolism"),(
+  "advertising render","product-launch CGI","impossible machinery","dramatic science-fiction scenery","decorative cables or components unsupported by the story","glowing components")),
+ _profile("constructed-collage-v1","profile-004",(
+  "visibly constructed paper editorial collage","cut-paper shapes","limited physical depth","tactile edges","restrained shadows","simplified symbolic relationships","analogue composition rather than digital photomontage"),(
+  "glossy digital collage","surreal accumulation of unrelated objects","floating UI","stock-photo montage","pseudo-3D layers","dense visual clutter")),
+ _profile("ink-gouache-v1","profile-005",(
+  "ink drawing and opaque gouache","visible brush and line variation","reduced forms","deliberate imperfections","controlled hand-rendered texture","a small number of strong masses","clear newspaper reproduction at reduced size"),(
+  "polished concept art","photorealism","airbrushed gradients","digital fantasy lighting","hyper-detailed backgrounds","smooth synthetic surfaces")),
+ _profile("cinematic-editorial-v1","profile-006",(
+  "controlled cinematic editorial illustration","realistic or strongly stylized rendering permitted","detailed environments permitted when they support the story","dramatic framing and atmosphere permitted","coherent spatial construction","restrained visual narrative tied directly to source facts","strong focal hierarchy despite environmental detail"),(
+  "generic cyberpunk imagery","gratuitous neon","floating particles used as decoration","glowing circuit-board motifs","monumental symbolism unrelated to the article","incoherent machinery or architecture","visual overload that obscures the central subject","polished game-concept-art clichés without editorial meaning")),
+)
+if len({p.profile_id for p in _REGISTERED})!=len(_REGISTERED) or len({p.internal_id for p in _REGISTERED})!=len(_REGISTERED):raise RuntimeError("duplicate_prompt_profile")
+PROMPT_PROFILES:Mapping[str,PromptProfile]=MappingProxyType({p.profile_id:p for p in _REGISTERED})
+BASELINE_PROFILE=PROMPT_PROFILES["baseline-v1"]
+
+def get_profile(profile_id:str)->PromptProfile:
+ try:return PROMPT_PROFILES[profile_id]
+ except KeyError as exc:raise KeyError("unknown_prompt_profile") from exc

--- a/tools/tldr_editorial/image.py
+++ b/tools/tldr_editorial/image.py
@@ -5,19 +5,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from .candidates import Candidate
 from .core import EditorialError,WEBP_METHOD,WEBP_QUALITY
-
-PREAMBLE="""Create a premium editorial illustration for a serious technology newspaper.
-
-The image is an editorial illustration, not documentary photography.
-Use one immediately readable focal subject.
-Use a strong, restrained composition with controlled contrast.
-Use sophisticated but understandable visual symbolism.
-Leave useful negative space around the focal subject.
-Do not render words, captions, headlines, logos, trademarks, interfaces, screenshots, charts, watermarks, or newspaper typography.
-Do not fabricate visible factual evidence.
-Do not imitate a named or living illustrator.
-Do not create a collage of unrelated news stories.
-The image must remain readable at newspaper-column and social-card sizes."""
+from .illustration_prompts import BASELINE_PROFILE,PromptProfile
 
 @dataclass(frozen=True)
 class ValidatedImage:
@@ -29,8 +17,8 @@ class ValidatedImage:
     @property
     def bytes(self)->int: return len(self.data)
 
-def assemble_prompt(brief:dict,source_candidates:list[Candidate])->str:
-    lines=[PREAMBLE,"","Source stories (use only these facts):"]
+def assemble_prompt(brief:dict,source_candidates:list[Candidate],profile:PromptProfile=BASELINE_PROFILE)->str:
+    lines=[profile.preamble,"","Source stories (use only these facts):"]
     for c in source_candidates: lines += [f"Title: {c.title}",f"Summary: {c.summary}"]
     lines += ["",f"Central subject: {brief['central_subject']}",f"Visual metaphor: {brief['visual_metaphor']}",f"Composition: {brief['composition']}",
               "Forbidden elements: "+(", ".join(brief["forbidden_elements"]) or "none beyond the fixed restrictions")]


### PR DESCRIPTION
## Summary

Adds an isolated, human-scored illustration prompt calibration lab without changing production art direction or publication behavior.

Production remains pinned to byte-identical `baseline-v1`; `ILLUSTRATION_PROMPT_VERSION` is unchanged. Calibration never calls the editorial model, writes official editorial JSON, uploads to R2, or exposes profile identities in the blind gallery.

## Declarative profiles

Immutable versioned profiles are registered in one data registry. The calibration engine, safety checks, image normalization, gallery, and evaluation format contain no profile count or profile-ID list, so future directions require only declarative registration.

Available profiles:

- `baseline-v1`
- `print-graphic-v1`
- `object-study-v1`
- `constructed-collage-v1`
- `ink-gouache-v1`
- `cinematic-editorial-v1`

Shared restrictions are limited to factual/safety constraints: visible text, logos/trademarks, fabricated evidence, interfaces/screenshots, and imitation of named/living artists. All aesthetic exclusions remain profile-specific.

## CLI

Zero-network planning example:

```bash
python -m tools.tldr_editorial calibrate-images \
  --date 2026-07-21 \
  --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
  --output-dir /home/galois/tldr-image-calibration/round-1 \
  --samples-per-profile 2 --max-images 12
```

Explicit live form for a later authorized experiment:

```bash
python -m tools.tldr_editorial calibrate-images \
  --date 2026-07-21 \
  --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
  --output-dir /home/galois/tldr-image-calibration/round-1 \
  --samples-per-profile 2 \
  --require-live --acknowledge-cost --max-images 12
```

Live calibration requires a clean non-CI checkout, both cost acknowledgements, an explicit count ceiling, and an absolute empty non-symlink output outside Git. `--samples-per-profile` defaults to 1, accepts 1–5, and multiplies the selected-profile count for `--max-images` enforcement. Repeated candidates have independent anonymous IDs but identical profile prompts and facts. It makes image calls only, does not retry a failed candidate, never constructs R2 storage, and uses production decoding/WebP normalization.

## Outputs and scoring

Writes anonymous WebPs (live only), `manifest.json`, private `blind-map.json`, local `gallery.html`, and `score-template.json`. The gallery randomizes anonymous candidates, repeats identical source facts and framing, and contains no profile IDs or mapping.

The documented human rubric weights AI-cliché avoidance, editorial authorship, factual grounding, composition, newspaper fit, and small-size readability, with explicit hard rejections. Round 1 uses two samples for each of six profiles—twelve image calls—to judge both quality and consistency. With the four-call finalist round, the documented protocol totals sixteen image calls across three story types and zero editorial calls. Winner locking is documented as a later separate versioned PR.

## Changed files

- `tools/tldr_editorial/illustration_prompts.py`
- `tools/tldr_editorial/calibration.py`
- `tools/tldr_editorial/image.py`
- `tools/tldr_editorial/cli.py`
- `tests_editorial/test_illustration_calibration.py`
- `docs/ILLUSTRATION_CALIBRATION.md`

## Verification

- derive: 46 passed
- raw privacy: 16 passed
- pipeline: 24 passed
- deployment: 17 passed
- editorial: 85 passed
- Worker: 13 passed
- total: 201 passed
- Bash syntax: passed
- strict normalized privacy: 5,939 sources, zero errors/hits
- normalized consistency: passed
- editorial consistency: passed
- real repeated-planning smoke test: twelve anonymous candidates, two samples per profile, identical per-profile prompt hashes, zero image/editorial/R2 calls, zero generated images

No paid image was generated. No OpenRouter or R2 call occurred. No generated artifact, production R2 object, production prompt version, production default prompt bytes, or frontend code changed.
