### PR TITLE
Separate editorial concepts from illustration styles

### DIFF
--- a/docs/ILLUSTRATION_CALIBRATION.md
+++ b/docs/ILLUSTRATION_CALIBRATION.md
@@ -2,7 +2,7 @@
 
 This lab compares immutable prompt profiles against one already validated Daily visual brief. It is isolated from normal publication: it never calls the editorial model, writes official editorial JSON, or uploads to R2. Production remains pinned to `baseline-v1` and the current `ILLUSTRATION_PROMPT_VERSION` until a separate winner-locking change is reviewed.
 
-Profiles are registered declaratively in `tools/tldr_editorial/illustration_prompts.py`. The calibration engine, safety policy, normalizer, gallery, and scoring format do not contain a profile count or list. Adding a direction requires registering another immutable profile; callers still explicitly choose profiles and cap the candidate count.
+Rendering styles are registered declaratively in `tools/tldr_editorial/illustration_prompts.py`. Editorial visual concepts are independently registered in `tools/tldr_editorial/illustration_concepts.py`. The calibration engine forms an explicit Cartesian product; neither registry depends on the other, and production still uses its validated visual brief with `baseline-v1` exactly as before. The safety policy, normalizer, gallery, and scoring format contain no profile count or ID list.
 
 ## Profiles available initially
 
@@ -13,7 +13,18 @@ Profiles are registered declaratively in `tools/tldr_editorial/illustration_prom
 - `ink-gouache-v1`: reduced ink and opaque-gouache drawing.
 - `cinematic-editorial-v1`: coherent, source-grounded cinematic framing and atmosphere.
 
-Only factual and safety restrictions are shared: no visible text, logos/trademarks, fabricated evidence, interfaces/screenshots, or imitation of named/living artists. Photorealism, concept art, detail, gradients, surfaces, and other aesthetic choices are profile-specific.
+Only factual and safety restrictions are shared: no visible text, logos/trademarks, fabricated evidence, interfaces/screenshots, or imitation of named/living artists. Photorealism, concept art, detail, gradients, surfaces, and other aesthetic choices are style-specific.
+
+## AMD Helios concept profiles
+
+- `integrated-stack-v1`: distinct modules converge into one integrated system.
+- `challenger-enters-v1`: a credible smaller engineered structure disrupts an established field.
+- `system-to-buyer-v1`: construction connects directionally to receiving infrastructure.
+- `industrial-scale-v1`: density, modularity, assembly, and human-relative infrastructure scale.
+- `architecture-rivalry-v1`: contrasting system architectures without literal combat.
+- `small-share-large-ambition-v1`: spatial contrast between a small footprint and credible infrastructure ambition.
+
+Concepts may override only central subject, visual metaphor, composition, and concept-specific forbidden elements. They contain factual rationale and optional source-reference requirements, but no rendering medium, palette, lighting, or material treatment. Calibration records hashes for both the original validated brief and the experimental concept. A calibration-only anti-default clause rejects the centered heroic rack/tower idea unless a selected concept genuinely requires it.
 
 ## Safe usage
 
@@ -22,9 +33,10 @@ Planning mode writes blind experiment files but makes zero network calls:
 ```bash
 python -m tools.tldr_editorial calibrate-images \
   --date 2026-07-21 \
-  --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
-  --output-dir /home/galois/tldr-image-calibration/round-1 \
-  --samples-per-profile 2 --max-images 12
+  --style-profiles print-graphic-v1,constructed-collage-v1 \
+  --concepts integrated-stack-v1,challenger-enters-v1,system-to-buyer-v1,industrial-scale-v1,architecture-rivalry-v1,small-share-large-ambition-v1 \
+  --output-dir /home/galois/tldr-image-calibration/round-1b \
+  --samples-per-combination 1 --max-images 12
 ```
 
 A live run is accepted only with both explicit acknowledgements:
@@ -32,15 +44,16 @@ A live run is accepted only with both explicit acknowledgements:
 ```bash
 python -m tools.tldr_editorial calibrate-images \
   --date 2026-07-21 \
-  --profiles baseline-v1,print-graphic-v1,object-study-v1,constructed-collage-v1,ink-gouache-v1,cinematic-editorial-v1 \
-  --output-dir /home/galois/tldr-image-calibration/round-1 \
-  --samples-per-profile 2 \
+  --style-profiles print-graphic-v1,constructed-collage-v1 \
+  --concepts integrated-stack-v1,challenger-enters-v1,system-to-buyer-v1,industrial-scale-v1,architecture-rivalry-v1,small-share-large-ambition-v1 \
+  --output-dir /home/galois/tldr-image-calibration/round-1b \
+  --samples-per-combination 1 \
   --require-live --acknowledge-cost --max-images 12
 ```
 
-The output must be absolute, outside Git, non-symlinked, and empty. The checkout must be clean. CI live runs are forbidden. `--samples-per-profile` defaults to one and accepts one through five; the explicit `--max-images` ceiling applies to profiles multiplied by samples. Repeated samples receive independent anonymous IDs while using identical prompts and source facts. No candidate is automatically retried; after one failure, it and all unattempted candidates are recorded and paid calls stop.
+The output must be absolute, outside Git, non-symlinked, and empty. The checkout must be clean. CI live runs are forbidden. `--samples-per-combination` defaults to one and accepts one through three; `--max-images` covers styles × concepts × samples. `--profiles` and `--samples-per-profile` remain aliases for the original style-only experiment. Repeated samples receive independent anonymous IDs while using identical prompts and source facts. No candidate is automatically retried; after one failure, it and all unattempted candidates are recorded and paid calls stop.
 
-Outputs are `manifest.json`, private `blind-map.json`, `gallery.html`, `score-template.json`, and (live only) normalized anonymous WebPs. The gallery works through `file://`, randomizes anonymous candidates, uses identical framing, repeats identical source facts, and never includes profile IDs. Keep `blind-map.json` private until scoring is complete.
+Outputs are `manifest.json`, private `blind-map.json`, `gallery.html`, `score-template.json`, and (live only) normalized anonymous WebPs. The private map stores style, concept, and sample. The public manifest and gallery expose none. The self-contained `file://` gallery randomizes anonymous candidates, shows source facts once, uses at most three large columns (one on narrow screens), keeps identical 3:2 framing, and offers local click-to-enlarge. Keep `blind-map.json` private until scoring is complete.
 
 ## Human scoring rubric
 
@@ -59,17 +72,13 @@ Hard reject visible text/malformed lettering, logos/trademarks, invented evidenc
 
 For each image also record a one-sentence first impression, strongest quality, strongest weakness, whether it feels human-directed, and whether it should advance. Human judgment is authoritative; this version does not ask another model to score aesthetics.
 
-## Two-round protocol (documented, not executed here)
+## Round 1B protocol (documented, not executed here)
 
-### Round 1
+Round 1 showed that style changes alone still converged on a centered heroic rack. No image won. Based on best-sample quality, pair consistency, low obvious-AI appearance, and newspaper suitability, advance `print-graphic-v1` and `constructed-collage-v1`; baseline advances only if human ranking explicitly places it in the top two.
 
-Use the existing AMD Helios visual brief. Generate two independent anonymous samples for each of the six initial profiles, rank blindly on both quality and consistency, and retain two profiles. Both samples for a profile use the exact same prompt and facts. This is twelve paid image calls and zero editorial calls.
+For concept discovery, cross the two selected styles with all six AMD concepts and use one sample per combination: twelve image calls, zero editorial calls, no R2, and no official artifact mutation. Review blindly and retain the two strongest style/concept combinations.
 
-### Round 2
-
-Select two additional validated briefs with different visual problems: one abstract software/model story and one human, organizational, or economic technology story. Generate both finalists against both briefs, then rank blindly. This is four paid image calls and zero editorial calls.
-
-The initial repeated-sampling experiment therefore uses sixteen image calls total, zero editorial calls, no R2 uploads, and no official artifact mutation. Registry growth or sampling changes the total only when the operator explicitly selects profiles, chooses a sample count, and raises `--max-images`. A winner must perform well across all three story types; the AMD result alone cannot select production direction.
+Then generate two additional samples for each finalist: four calls for consistency evaluation. Do not select from a single attractive sample. A later cross-story round must still verify any eventual direction on abstract software/model and human/organizational/economic technology stories.
 
 ## Later winner lock (not part of calibration)
 

--- a/tests_editorial/test_illustration_calibration.py
+++ b/tests_editorial/test_illustration_calibration.py
@@ -4,10 +4,11 @@ from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import patch
 from PIL import Image
-from tools.tldr_editorial.calibration import CalibrationContext,calibrate_images,run_calibration
+from tools.tldr_editorial.calibration import AMD_ANTI_DEFAULT_CLAUSE,CalibrationContext,assemble_experimental_prompt,calibrate_images,read_blind_mapping,run_calibration
 from tools.tldr_editorial.candidates import Candidate
 from tools.tldr_editorial.core import EditorialError
 from tools.tldr_editorial.image import assemble_prompt,decode_image,normalize_raster
+from tools.tldr_editorial.illustration_concepts import CONCEPT_PROFILES,ConceptProfile
 from tools.tldr_editorial.illustration_prompts import BASELINE_PREAMBLE,BASELINE_PROFILE,PROMPT_PROFILES,PromptProfile,SHARED_FACTUAL_RESTRICTIONS
 from tools.tldr_editorial.openrouter import Result
 from tests_editorial.helpers import config
@@ -25,7 +26,7 @@ Do not imitate a named or living illustrator.
 Do not create a collage of unrelated news stories.
 The image must remain readable at newspaper-column and social-card sizes."""
 
-def candidate():return Candidate("c001","issue","article","tldr","NEWS","AMD Helios rack system","AMD introduced a rack-scale AI system with physically integrated compute and networking.","https://example.com/story","example.com",3,"editorial",(0,0))
+def candidate():return Candidate("c001","tldr:2026-07-21","tldr:2026-07-21:a09","tldr","NEWS","AMD Helios rack system","AMD introduced a rack-scale AI system with physically integrated compute and networking.","https://example.com/story","example.com",3,"editorial",(0,0))
 def context():return CalibrationContext("2026-07-21",{"mode":"lead_story","central_subject":"one rack-scale computing system","visual_metaphor":"industrial presence","composition":"single centered rack in a wide frame","forbidden_elements":["unsupported components"],"alt_text":"A rack-scale computing system"},(candidate(),))
 def png_value():
  out=io.BytesIO();Image.new("RGB",(600,400),(80,90,100)).save(out,format="PNG");return base64.b64encode(out.getvalue()).decode()
@@ -57,21 +58,40 @@ class CalibrationTests(unittest.TestCase):
  def test_prompt_assembly_is_deterministic_and_profiles_do_not_change_facts(self):
   prompts=[assemble_prompt(context().brief,[candidate()],p) for p in PROMPT_PROFILES.values()]
   self.assertEqual(prompts,[assemble_prompt(context().brief,[candidate()],p) for p in PROMPT_PROFILES.values()]);self.assertTrue(all(candidate().title in x and candidate().summary in x for x in prompts));self.assertGreater(len(set(prompts)),1)
+ def test_style_and_concept_registries_are_independent_and_declarative(self):
+  self.assertTrue(CONCEPT_PROFILES);self.assertTrue(PROMPT_PROFILES);self.assertFalse(set(CONCEPT_PROFILES)&set(PROMPT_PROFILES));self.assertEqual(len(CONCEPT_PROFILES),len(set(CONCEPT_PROFILES)))
+  concept_fields=set(ConceptProfile.__dataclass_fields__);style_fields=set(PromptProfile.__dataclass_fields__)
+  self.assertFalse(concept_fields&{"rendering_style","medium","palette","lighting","material_treatment"});self.assertFalse(style_fields&{"central_subject_override","visual_metaphor_override","composition_override","factual_rationale","required_source_references"})
+  style_text=" ".join(x.preamble for x in PROMPT_PROFILES.values()).lower();self.assertTrue(all(term not in style_text for term in ("amd","helios","microsoft","nvidia")))
+ def test_experimental_prompt_is_deterministic_replaces_concept_and_keeps_exact_facts(self):
+  concept=CONCEPT_PROFILES["integrated-stack-v1"];style=PROMPT_PROFILES["print-graphic-v1"];original=json.loads(json.dumps(context().brief));prompt=assemble_experimental_prompt(context(),style,concept)
+  self.assertEqual(prompt,assemble_experimental_prompt(context(),style,concept));self.assertIn(candidate().title,prompt);self.assertIn(candidate().summary,prompt);self.assertIn(concept.central_subject_override,prompt);self.assertIn(AMD_ANTI_DEFAULT_CLAUSE,prompt);self.assertNotIn(original["central_subject"],prompt);self.assertEqual(context().brief,original)
  def test_dry_default_has_zero_calls_and_never_writes_official_artifacts(self):
   official=self.repo/"generated/editorial/manifest.json";official.parent.mkdir(parents=True);official.write_bytes(b"official\n");subprocess.run(["git","add","generated"],check=True);subprocess.run(["git","commit","-m","official"],check=True,capture_output=True)
   client=ImageClient();result=calibrate_images(date=context().date,profile_ids=list(PROMPT_PROFILES),output_dir=self.output(),max_images=len(PROMPT_PROFILES),config=config(),client=client,context=context())
   self.assertEqual((result["network_calls"],result["editorial_calls"],result["r2_calls"]),(0,0,0));self.assertEqual(client.image_calls,0);self.assertEqual(client.editorial_calls,0);self.assertEqual(official.read_bytes(),b"official\n")
  def test_default_one_sample_per_profile(self):
   out=self.output();selected=list(PROMPT_PROFILES)[:2];result=calibrate_images(date=context().date,profile_ids=selected,output_dir=out,max_images=2,config=config(),context=context())
-  mapping=json.loads((out/"blind-map.json").read_text())["mapping"];self.assertEqual(result["candidate_count"],2);self.assertEqual({x["sample_index"] for x in mapping.values()},{1});self.assertEqual({x["profile_id"] for x in mapping.values()},set(selected))
+  mapping=json.loads((out/"blind-map.json").read_text())["mapping"];self.assertEqual(result["candidate_count"],2);self.assertEqual({x["sample_index"] for x in mapping.values()},{1});self.assertEqual({x["style_profile_id"] for x in mapping.values()},set(selected));self.assertEqual({x["concept_profile_id"] for x in mapping.values()},{"official-visual-brief"})
  def test_two_samples_are_anonymous_complete_and_use_identical_profile_prompts(self):
   out=self.output();selected=list(PROMPT_PROFILES)[:2];client=ImageClient();result=calibrate_images(date=context().date,profile_ids=selected,output_dir=out,max_images=4,samples_per_profile=2,config=config(),client=client,context=context())
   manifest=json.loads((out/"manifest.json").read_text());mapping=json.loads((out/"blind-map.json").read_text())["mapping"];gallery=(out/"gallery.html").read_text();ids=[x["candidate_id"] for x in manifest["candidates"]]
   self.assertEqual(result["candidate_count"],4);self.assertEqual(len(ids),len(set(ids)));self.assertEqual(set(ids),set(mapping));self.assertEqual(client.image_calls,0)
   for profile_id in selected:
-   members={candidate_id for candidate_id,value in mapping.items() if value=={"profile_id":profile_id,"sample_index":1} or value=={"profile_id":profile_id,"sample_index":2}}
+   members={candidate_id for candidate_id,value in mapping.items() if value["style_profile_id"]==profile_id}
    self.assertEqual(len(members),2);self.assertEqual(len({x["prompt_sha256"] for x in manifest["candidates"] if x["candidate_id"] in members}),1)
   self.assertTrue(all(profile_id not in gallery and profile_id not in (out/"manifest.json").read_text() for profile_id in selected));self.assertNotIn("sample_index",gallery);self.assertNotIn("sample_index",(out/"manifest.json").read_text())
+ def test_cartesian_concept_count_hash_relationships_blindness_and_maximum(self):
+  official=self.repo/"generated/editorial/manifest.json";official.parent.mkdir(parents=True);official.write_bytes(b"official\n");subprocess.run(["git","add","generated"],check=True);subprocess.run(["git","commit","-m","official"],check=True,capture_output=True)
+  out=self.output();styles=list(PROMPT_PROFILES)[:2];concepts=list(CONCEPT_PROFILES)[:3];client=ImageClient();result=calibrate_images(date=context().date,profile_ids=styles,concept_ids=concepts,output_dir=out,max_images=12,samples_per_combination=2,config=config(),client=client,context=context());self.assertEqual(official.read_bytes(),b"official\n")
+  self.assertEqual(result["candidate_count"],12);self.assertEqual((result["network_calls"],result["editorial_calls"],result["r2_calls"]),(0,0,0));self.assertEqual((client.image_calls,client.editorial_calls),(0,0))
+  manifest=json.loads((out/"manifest.json").read_text());mapping=json.loads((out/"blind-map.json").read_text())["mapping"];gallery=(out/"gallery.html").read_text();manifest_text=(out/"manifest.json").read_text();by={x["candidate_id"]:x for x in manifest["candidates"]}
+  self.assertEqual(set(mapping),set(by));self.assertTrue(all(set(v)=={"style_profile_id","concept_profile_id","sample_index"} for v in mapping.values()))
+  hashes={(s,c):{by[cid]["prompt_sha256"] for cid,v in mapping.items() if v["style_profile_id"]==s and v["concept_profile_id"]==c} for s in styles for c in concepts}
+  self.assertTrue(all(len(value)==1 for value in hashes.values()));self.assertNotEqual(hashes[(styles[0],concepts[0])],hashes[(styles[0],concepts[1])]);self.assertNotEqual(hashes[(styles[0],concepts[0])],hashes[(styles[1],concepts[0])])
+  self.assertTrue(all(x.get("original_visual_brief_sha256") and x.get("experimental_concept_sha256") for x in by.values()));self.assertTrue(all(value not in gallery and value not in manifest_text for value in styles+concepts));self.assertNotIn("sample_index",gallery);self.assertNotIn("sample_index",manifest_text)
+  self.assertEqual(gallery.count(candidate().title),1);self.assertEqual(gallery.count(candidate().summary),1);self.assertIn("grid-template-columns:repeat(3",gallery);self.assertIn("<dialog",gallery)
+  with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_images(date=context().date,profile_ids=styles,concept_ids=concepts,output_dir=self.output("too-many"),max_images=11,samples_per_combination=2,config=config(),context=context())
  def test_live_requires_both_flags_ci_is_forbidden_and_limit_is_enforced(self):
   ids=["baseline-v1"]
   for flags in ({"require_live":True},{"acknowledge_cost":True}):
@@ -82,6 +102,9 @@ class CalibrationTests(unittest.TestCase):
   with self.assertRaisesRegex(EditorialError,"calibration_duplicate_profile"):calibrate_images(date=context().date,profile_ids=ids*2,output_dir=self.output("duplicate"),max_images=2,config=config(),context=context())
   for value in (0,6):
    with self.assertRaisesRegex(EditorialError,"calibration_samples_per_profile_invalid"):calibrate_images(date=context().date,profile_ids=ids,output_dir=self.output("samples"+str(value)),max_images=10,samples_per_profile=value,config=config(),context=context())
+  for value in (0,4):
+   with self.assertRaisesRegex(EditorialError,"calibration_samples_per_combination_invalid"):calibrate_images(date=context().date,profile_ids=ids,concept_ids=["integrated-stack-v1"],output_dir=self.output("combinations"+str(value)),max_images=10,samples_per_combination=value,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_duplicate_concept"):calibrate_images(date=context().date,profile_ids=ids,concept_ids=["integrated-stack-v1"]*2,output_dir=self.output("duplicate-concept"),max_images=2,config=config(),context=context())
  def test_output_inside_git_and_symlink_are_rejected(self):
   with self.assertRaisesRegex(EditorialError,"calibration_output_inside_git"):calibrate_images(date=context().date,profile_ids=["baseline-v1"],output_dir=self.repo/"inside",max_images=1,config=config(),context=context())
   target=self.output("target");target.mkdir();link=self.output("link");link.symlink_to(target,True)
@@ -93,7 +116,7 @@ class CalibrationTests(unittest.TestCase):
    if kwargs.get("prefix",args[0] if args else "").startswith("tldr-calibration-provider-"):tracked.append(path)
    return fd,path
   with patch.dict(os.environ,{"CI":""}),patch("tools.tldr_editorial.calibration.tempfile.mkstemp",side_effect=recording),patch("tools.tldr_editorial.r2_storage.R2Storage",side_effect=AssertionError("R2 called")) as r2:
-   result=calibrate_images(date=context().date,profile_ids=["print-graphic-v1"],output_dir=out,max_images=1,require_live=True,acknowledge_cost=True,config=config(api_key="x"),client=client,context=context())
+   result=calibrate_images(date=context().date,profile_ids=["print-graphic-v1"],concept_ids=["integrated-stack-v1"],output_dir=out,max_images=1,require_live=True,acknowledge_cost=True,config=config(api_key="x"),client=client,context=context())
   self.assertTrue(result["success"]);self.assertEqual((client.image_calls,client.editorial_calls),(1,0));self.assertEqual(result["r2_calls"],0);r2.assert_not_called();self.assertTrue(tracked);self.assertTrue(all(not Path(x).exists() for x in tracked))
   manifest=json.loads((out/"manifest.json").read_text());record=manifest["candidates"][0];self.assertEqual(record["usage"]["cost_usd"],0.125);data=(out/record["image_file"]).read_bytes();self.assertEqual(record["sha256"],"sha256:"+hashlib.sha256(data).hexdigest())
   raw,media=decode_image(png_value(),"image/png");source=self.output("source.raster");source.write_bytes(raw);expected=normalize_raster(source,media,config().max_provider_image_bytes,config().max_image_pixels,config().max_image_bytes);self.assertEqual(data,expected.data)
@@ -106,6 +129,9 @@ class CalibrationTests(unittest.TestCase):
   out=self.output();client=ImageClient(fail=True);ids=list(PROMPT_PROFILES)[:3]
   with patch.dict(os.environ,{"CI":""}):result=calibrate_images(date=context().date,profile_ids=ids,output_dir=out,max_images=6,samples_per_profile=2,require_live=True,acknowledge_cost=True,config=config(api_key="x"),client=client,context=context())
   self.assertFalse(result["success"]);self.assertEqual(client.image_calls,1);records=json.loads((out/"manifest.json").read_text())["candidates"];self.assertEqual(sum(x["status"]=="failed" for x in records),1);self.assertEqual(sum(x["status"]=="not_attempted" for x in records),5);self.assertNotIn("request_id",json.dumps(records))
+ def test_existing_round_one_private_mapping_remains_readable(self):
+  path=self.output("old-map.json");path.write_text(json.dumps({"mapping":{"candidate-old":{"profile_id":"print-graphic-v1","sample_index":2}}}));value=read_blind_mapping(path)
+  self.assertEqual(value,{"candidate-old":{"style_profile_id":"print-graphic-v1","concept_profile_id":"official-visual-brief","sample_index":2}})
  def test_custom_registered_shape_needs_no_engine_count_change(self):
   out=self.output();out.mkdir();custom=PromptProfile("future-v1","profile-999","Future profile preamble",SHARED_FACTUAL_RESTRICTIONS,())
   result=run_calibration(context=context(),profiles=[custom],output=out,cfg=config(),live=False);self.assertEqual(result["candidate_count"],1);self.assertEqual(result["network_calls"],0)

--- a/tools/tldr_editorial/calibration.py
+++ b/tools/tldr_editorial/calibration.py
@@ -1,7 +1,7 @@
 """Isolated, human-scored illustration prompt calibration lab."""
 from __future__ import annotations
 import hashlib,html,json,os,secrets,subprocess,tempfile
-from dataclasses import dataclass
+from dataclasses import asdict,dataclass
 from pathlib import Path
 from typing import Sequence
 from .artifacts import load_artifact,validate_all
@@ -9,6 +9,7 @@ from .candidates import Candidate,load_date
 from .config import Config
 from .core import EditorialError
 from .image import assemble_prompt,decode_image,normalize_raster
+from .illustration_concepts import CONCEPT_SCHEMA_VERSION,ConceptProfile,get_concept
 from .illustration_prompts import PROFILE_SCHEMA_VERSION,PromptProfile,get_profile
 from .openrouter import OpenRouterClient
 
@@ -32,6 +33,25 @@ class CalibrationContext:
  date:str
  brief:dict
  sources:tuple[Candidate,...]
+
+AMD_ANTI_DEFAULT_CLAUSE="Do not default to a single centered server rack, a server represented as a skyscraper, a heroic product shot, an upward arrow, or a generic futuristic server room unless the selected concept explicitly requires it."
+
+def _digest(value:dict)->str:
+ return "sha256:"+hashlib.sha256(json.dumps(value,ensure_ascii=False,sort_keys=True,separators=(",",":")).encode()).hexdigest()
+
+def _official_concept(context:CalibrationContext)->ConceptProfile:
+ refs=tuple((c.issue_id,c.article_id) for c in context.sources);brief=context.brief
+ return ConceptProfile("official-visual-brief",brief["central_subject"],brief["visual_metaphor"],brief["composition"],tuple(brief["forbidden_elements"]),"Validated official editorial visual brief.",refs)
+
+def _concept_hash(concept:ConceptProfile)->str:return _digest(asdict(concept))
+def _original_brief_hash(context:CalibrationContext)->str:return _digest({"brief":context.brief,"source_references":[[c.issue_id,c.article_id] for c in context.sources]})
+
+def assemble_experimental_prompt(context:CalibrationContext,style:PromptProfile,concept:ConceptProfile)->str:
+ refs={(c.issue_id,c.article_id) for c in context.sources}
+ if concept.required_source_references and not set(concept.required_source_references).issubset(refs):raise EditorialError("calibration_concept_source_requirement_missing")
+ lines=[style.preamble,"","Experimental editorial concept:",f"Factual rationale: {concept.factual_rationale}",f"Central subject: {concept.central_subject_override}",f"Visual metaphor: {concept.visual_metaphor_override}",f"Composition: {concept.composition_override}","Concept-specific forbidden elements: "+(", ".join(concept.forbidden_elements) or "none"),"",AMD_ANTI_DEFAULT_CLAUSE,"","Source stories (use only these exact facts):"]
+ for source in context.sources:lines.extend((f"Title: {source.title}",f"Summary: {source.summary}"))
+ return "\n".join(lines).strip()+"\n"
 
 def _git_root()->Path:
  try:raw=subprocess.run(["git","rev-parse","--show-toplevel"],check=True,capture_output=True,timeout=10).stdout
@@ -85,41 +105,57 @@ def _atomic_bytes(path:Path,data:bytes,mode:int=0o600)->None:
 
 def _json(path:Path,value:dict,mode:int=0o600)->None:_atomic_bytes(path,(json.dumps(value,ensure_ascii=False,sort_keys=True,indent=2)+"\n").encode(),mode)
 
+def read_blind_mapping(path:Path)->dict:
+ """Read current or round-1 private maps without mutating either format."""
+ try:mapping=json.loads(path.read_text(encoding="utf-8"))["mapping"]
+ except (OSError,json.JSONDecodeError,KeyError,TypeError) as exc:raise EditorialError("calibration_blind_map_invalid") from exc
+ normalized={}
+ for candidate,value in mapping.items():
+  if not isinstance(value,dict):raise EditorialError("calibration_blind_map_invalid")
+  if "style_profile_id" in value:normalized[candidate]=dict(value)
+  elif "profile_id" in value:normalized[candidate]={"style_profile_id":value["profile_id"],"concept_profile_id":"official-visual-brief","sample_index":value.get("sample_index",1)}
+  else:raise EditorialError("calibration_blind_map_invalid")
+ return normalized
+
 def _gallery(candidates:list[dict],context:CalibrationContext)->str:
- source="".join(f"<p><strong>{html.escape(c.title)}</strong><br>{html.escape(c.summary)}</p>" for c in context.sources)
- cards=[]
+ source="".join(f"<p><strong>{html.escape(c.title)}</strong><br>{html.escape(c.summary)}</p>" for c in context.sources);cards=[]
  for c in candidates:
-  media=f'<img src="{html.escape(c["image_file"])}" alt="Anonymous calibration candidate">' if c.get("image_file") else '<div class="placeholder">No image generated</div>'
-  cards.append(f'<article><h2>{html.escape(c["candidate_id"])}</h2>{media}<div class="source">{source}</div></article>')
+  media=f'<button class="image-button" type="button" aria-label="Enlarge {html.escape(c["candidate_id"])}"><img src="{html.escape(c["image_file"])}" alt="Anonymous calibration candidate"></button>' if c.get("image_file") else '<div class="placeholder">No image generated</div>'
+  cards.append(f'<article>{media}<h2>{html.escape(c["candidate_id"])}</h2></article>')
  return """<!doctype html><meta charset="utf-8"><title>Blind illustration calibration</title>
-<style>body{font:16px system-ui;margin:2rem;background:#eee;color:#111}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:2rem}article{background:white;padding:1rem}img,.placeholder{display:block;width:100%;aspect-ratio:3/2;object-fit:cover;background:#ddd}.placeholder{display:grid;place-items:center}.source{font-size:.9rem}h2{font-size:1rem}</style>
-<h1>Blind illustration calibration</h1><div class="grid">"""+"".join(cards)+"</div>\n"
+<style>body{font:16px system-ui;margin:2rem auto;max-width:1800px;background:#eee;color:#111;padding:0 1rem}.source{max-width:900px;background:white;padding:1rem;margin-bottom:2rem}.grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1.5rem}article{background:white;padding:1rem}.image-button{display:block;width:100%;padding:0;border:0;background:none;cursor:zoom-in}img,.placeholder{display:block;width:100%;aspect-ratio:3/2;object-fit:cover;background:#ddd}.placeholder{display:grid;place-items:center}h2{font-size:1rem;margin:.75rem 0 0}dialog{border:0;padding:0;background:#111;max-width:95vw}dialog img{width:auto;max-width:95vw;max-height:92vh;aspect-ratio:auto;object-fit:contain}@media(max-width:800px){.grid{grid-template-columns:1fr}}</style>
+<h1>Blind illustration calibration</h1><section class="source"><h2>Source facts</h2>"""+source+"""</section><div class="grid">"""+"".join(cards)+"""</div><dialog id="zoom"><img alt="Enlarged anonymous candidate"></dialog><script>const d=document.querySelector('#zoom'),z=d.querySelector('img');document.querySelectorAll('.image-button img').forEach(i=>i.parentElement.addEventListener('click',()=>{z.src=i.src;d.showModal()}));d.addEventListener('click',()=>d.close());</script>\n"""
 
 def _write_outputs(output:Path,context:CalibrationContext,candidates:list[dict],mapping:dict)->None:
  order=list(candidates);secrets.SystemRandom().shuffle(order)
- manifest={"schema_version":CALIBRATION_SCHEMA_VERSION,"profile_schema_version":PROFILE_SCHEMA_VERSION,"date":context.date,"model":next((x["model"] for x in candidates),None),"source_context":[{"issue_id":c.issue_id,"article_id":c.article_id,"title":c.title,"summary":c.summary} for c in context.sources],"candidates":order}
+ manifest={"schema_version":CALIBRATION_SCHEMA_VERSION,"profile_schema_version":PROFILE_SCHEMA_VERSION,"concept_schema_version":CONCEPT_SCHEMA_VERSION,"date":context.date,"model":next((x["model"] for x in candidates),None),"source_context":[{"issue_id":c.issue_id,"article_id":c.article_id,"title":c.title,"summary":c.summary} for c in context.sources],"candidates":order}
  blind={"schema_version":CALIBRATION_SCHEMA_VERSION,"mapping":mapping}
  score={"schema_version":CALIBRATION_SCHEMA_VERSION,"rubric":RUBRIC,"scores":[{"candidate_id":x["candidate_id"],"hard_rejection":False,"hard_rejection_reasons":[],"ratings":{c["id"]:None for c in RUBRIC["weighted_criteria"]},"first_impression":"","strongest_quality":"","strongest_weakness":"","feels_human_directed":None,"advance_to_round_two":None} for x in order]}
  _json(output/"manifest.json",manifest);_json(output/"blind-map.json",blind);_json(output/"score-template.json",score)
  _atomic_bytes(output/"gallery.html",_gallery(order,context).encode(),0o600)
 
-def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile],output:Path,cfg:Config,live:bool,client=None,samples_per_profile:int=1)->dict:
- if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
- assignments=[(profile,sample_index) for profile in profiles for sample_index in range(1,samples_per_profile+1)];ids=[]
+def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile],output:Path,cfg:Config,live:bool,client=None,concepts:Sequence[ConceptProfile]|None=None,samples_per_combination:int=1,samples_per_profile:int|None=None)->dict:
+ legacy=concepts is None
+ if samples_per_profile is not None:
+  if not legacy or samples_per_combination!=1:raise EditorialError("calibration_sample_flags_conflict")
+  if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
+  samples_per_combination=samples_per_profile
+ elif not 1<=samples_per_combination<=3:raise EditorialError("calibration_samples_per_combination_invalid")
+ selected_concepts=list(concepts) if concepts is not None else [_official_concept(context)]
+ assignments=[(style,concept,sample_index) for style in profiles for concept in selected_concepts for sample_index in range(1,samples_per_combination+1)];ids=[]
  for _ in assignments:
   while True:
    value="candidate-"+secrets.token_hex(4)
    if value not in ids:ids.append(value);break
- mapping={candidate:{"profile_id":profile.profile_id,"sample_index":sample_index} for candidate,(profile,sample_index) in zip(ids,assignments)};records=[];failed=False;network_calls=0;image_client=(client or OpenRouterClient(cfg)) if live else None
- for candidate_id,(profile,sample_index) in zip(ids,assignments):
-  prompt=assemble_prompt(context.brief,list(context.sources),profile);prompt_sha="sha256:"+hashlib.sha256(prompt.encode()).hexdigest()
-  record={"candidate_id":candidate_id,"status":"planned" if not live else "not_attempted","image_file":None,"sha256":None,"width":None,"height":None,"bytes":None,"prompt_sha256":prompt_sha,"model":cfg.image_model,"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"cost_usd":0.0},"source_references":[{"issue_id":c.issue_id,"article_id":c.article_id} for c in context.sources]}
+ mapping={candidate:{"style_profile_id":style.profile_id,"concept_profile_id":concept.concept_id,"sample_index":sample_index} for candidate,(style,concept,sample_index) in zip(ids,assignments)};records=[];failed=False;network_calls=0;image_client=(client or OpenRouterClient(cfg)) if live else None;original_hash=_original_brief_hash(context)
+ for candidate_id,(style,concept,sample_index) in zip(ids,assignments):
+  prompt=assemble_prompt(context.brief,list(context.sources),style) if legacy else assemble_experimental_prompt(context,style,concept);prompt_sha="sha256:"+hashlib.sha256(prompt.encode()).hexdigest()
+  record={"candidate_id":candidate_id,"status":"planned" if not live else "not_attempted","image_file":None,"sha256":None,"width":None,"height":None,"bytes":None,"prompt_sha256":prompt_sha,"original_visual_brief_sha256":original_hash,"experimental_concept_sha256":_concept_hash(concept),"model":cfg.image_model,"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"cost_usd":0.0},"source_references":[{"issue_id":c.issue_id,"article_id":c.article_id} for c in context.sources]}
   records.append(record)
   if not live or failed:continue
   try:
    network_calls+=1;result=image_client.image(prompt)
-   raw,media=decode_image(result.value,result.media_type)
-   fd,tmp=tempfile.mkstemp(prefix="tldr-calibration-provider-",suffix=".raster")
+   raw,media=decode_image(result.value,result.media_type);fd,tmp=tempfile.mkstemp(prefix="tldr-calibration-provider-",suffix=".raster")
    try:
     os.fchmod(fd,0o600)
     with os.fdopen(fd,"wb") as handle:handle.write(raw);handle.flush();os.fsync(handle.fileno())
@@ -127,22 +163,32 @@ def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile
    finally:
     try:os.unlink(tmp)
     except FileNotFoundError:pass
-   filename=candidate_id+".webp";_atomic_bytes(output/filename,image.data)
-   record.update(status="ready",image_file=filename,sha256=image.sha256,width=image.width,height=image.height,bytes=image.bytes,usage=result.usage)
-  except EditorialError as exc:
-   record.update(status="failed",failure_category=str(exc));failed=True
+   filename=candidate_id+".webp";_atomic_bytes(output/filename,image.data);record.update(status="ready",image_file=filename,sha256=image.sha256,width=image.width,height=image.height,bytes=image.bytes,usage=result.usage)
+  except EditorialError as exc:record.update(status="failed",failure_category=str(exc));failed=True
  _write_outputs(output,context,records,mapping)
  return {"date":context.date,"candidate_count":len(records),"ready_count":sum(x["status"]=="ready" for x in records),"failed_count":sum(x["status"]=="failed" for x in records),"network_calls":network_calls,"editorial_calls":0,"r2_calls":0,"live":live,"success":not failed,"output_dir":str(output)}
 
-def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_images:int,samples_per_profile:int=1,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
+def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_images:int,concept_ids:Sequence[str]|None=None,samples_per_combination:int=1,samples_per_profile:int|None=None,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
  if not date:raise EditorialError("calibration_date_required")
  if not profile_ids:raise EditorialError("calibration_profiles_required")
- if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
- total=len(profile_ids)*samples_per_profile
- if max_images<1 or total>max_images:raise EditorialError("calibration_image_limit")
  if len(set(profile_ids))!=len(profile_ids):raise EditorialError("calibration_duplicate_profile")
  try:profiles=[get_profile(x) for x in profile_ids]
  except KeyError as exc:raise EditorialError("calibration_profile_unknown") from exc
+ concepts=None
+ if concept_ids is not None:
+  if not concept_ids:raise EditorialError("calibration_concepts_required")
+  if len(set(concept_ids))!=len(concept_ids):raise EditorialError("calibration_duplicate_concept")
+  try:concepts=[get_concept(x) for x in concept_ids]
+  except KeyError as exc:raise EditorialError("calibration_concept_unknown") from exc
+ if samples_per_profile is not None:
+  if concepts is not None or samples_per_combination!=1:raise EditorialError("calibration_sample_flags_conflict")
+  if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
+  samples=samples_per_profile
+ else:
+  if not 1<=samples_per_combination<=3:raise EditorialError("calibration_samples_per_combination_invalid")
+  samples=samples_per_combination
+ total=len(profiles)*(len(concepts) if concepts is not None else 1)*samples
+ if max_images<1 or total>max_images:raise EditorialError("calibration_image_limit")
  if require_live!=acknowledge_cost:raise EditorialError("calibration_live_flags_required")
  live=require_live and acknowledge_cost
  if live and os.getenv("CI"):raise EditorialError("calibration_live_forbidden_in_ci")
@@ -150,4 +196,4 @@ def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_im
  if live:cfg.require_openrouter()
  context=context or _context(date,generated,editorial_output,cfg)
  if context.date!=date:raise EditorialError("calibration_context_date_mismatch")
- return run_calibration(context=context,profiles=profiles,output=output,cfg=cfg,live=live,client=client,samples_per_profile=samples_per_profile)
+ return run_calibration(context=context,profiles=profiles,concepts=concepts,output=output,cfg=cfg,live=live,client=client,samples_per_combination=samples if samples_per_profile is None else 1,samples_per_profile=samples_per_profile)

--- a/tools/tldr_editorial/cli.py
+++ b/tools/tldr_editorial/cli.py
@@ -16,7 +16,7 @@ def parser():
     for x in ("force","retry-image","dry-run","offline","require-live"): g.add_argument("--"+x,action="store_true")
     v=sub.add_parser("validate"); v.add_argument("--all",action="store_true",required=True); v.add_argument("--output",type=Path,default=Path("generated/editorial")); v.add_argument("--generated",type=Path,default=Path("generated")); v.add_argument("--verify-storage",action="store_true")
     s=sub.add_parser("storage-report"); s.add_argument("--output",type=Path,default=Path("generated/editorial")); s.add_argument("--list-r2",action="store_true")
-    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);c.add_argument("--profiles",required=True);c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);c.add_argument("--samples-per-profile",type=int,default=1);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
+    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);styles=c.add_mutually_exclusive_group(required=True);styles.add_argument("--style-profiles");styles.add_argument("--profiles");c.add_argument("--concepts");c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);samples=c.add_mutually_exclusive_group();samples.add_argument("--samples-per-combination",type=int);samples.add_argument("--samples-per-profile",type=int);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
     return p
 
 def main(argv=None):
@@ -26,8 +26,8 @@ def main(argv=None):
             result=generate(generated=a.generated,output=a.output,date=a.date,latest=a.latest or not a.date,offline=a.offline,dry_run=a.dry_run,require_live=a.require_live,force=a.force,retry_image=a.retry_image)
             print(json.dumps(result,sort_keys=True)); return 0
         if a.command=="calibrate-images":
-            ids=[x.strip() for x in a.profiles.split(",") if x.strip()]
-            result=calibrate_images(date=a.date,profile_ids=ids,output_dir=a.output_dir,max_images=a.max_images,samples_per_profile=a.samples_per_profile,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
+            style_value=a.style_profiles or a.profiles;ids=[x.strip() for x in style_value.split(",") if x.strip()];concept_ids=[x.strip() for x in a.concepts.split(",") if x.strip()] if a.concepts is not None else None
+            result=calibrate_images(date=a.date,profile_ids=ids,concept_ids=concept_ids,output_dir=a.output_dir,max_images=a.max_images,samples_per_combination=a.samples_per_combination if a.samples_per_combination is not None else 1,samples_per_profile=a.samples_per_profile,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
             print(json.dumps(result,sort_keys=True));return 0 if result["success"] else 1
         if a.command=="validate":
             cfg=Config.from_env(); storage=R2Storage(cfg) if a.verify_storage else None

--- a/tools/tldr_editorial/illustration_concepts.py
+++ b/tools/tldr_editorial/illustration_concepts.py
@@ -1,0 +1,34 @@
+"""Immutable experimental editorial concepts, independent of rendering style."""
+from __future__ import annotations
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+CONCEPT_SCHEMA_VERSION="1.0.0"
+HELIOS_SOURCE_REFERENCES=(("tldr:2026-07-21","tldr:2026-07-21:a09"),)
+
+@dataclass(frozen=True)
+class ConceptProfile:
+ concept_id:str
+ central_subject_override:str
+ visual_metaphor_override:str
+ composition_override:str
+ forbidden_elements:tuple[str,...]
+ factual_rationale:str
+ required_source_references:tuple[tuple[str,str],...]=()
+ schema_version:str=CONCEPT_SCHEMA_VERSION
+
+_REGISTERED=(
+ ConceptProfile("integrated-stack-v1","Several distinct structural modules becoming one coherent physical system","Separate GPUs, CPUs, networking, and software layers converge into one integrated rack-scale system","Asymmetrical assembly or convergence; separate layers must visibly become one system",("one isolated centered rack","skyscraper metaphor","upward arrow","generic server room","decorative circuit patterns","unrelated floating components"),"AMD is combining GPUs, CPUs, networking, and software into one rack-scale system; integration is the editorial point, not a heroic rack.",HELIOS_SOURCE_REFERENCES),
+ ConceptProfile("challenger-enters-v1","A smaller but substantial engineered structure entering a field dominated by a larger established mass","An alternative engineered system creates tension within an established field without depicting literal conflict","Use scale, spacing, tension, or opposing forms; keep the smaller structure credible and materially substantial",("literal David-and-Goliath imagery","logos","mascots","chess pieces","boxing","weapons","two generic glowing towers","combat clichés","upward growth arrows","triumphant advertising composition"),"AMD has a relatively small data-center GPU position and is making a large rack-scale move against the dominant incumbent.",HELIOS_SOURCE_REFERENCES),
+ ConceptProfile("system-to-buyer-v1","A constructed rack-scale system in a directional relationship with receiving infrastructure","A system moves from construction into deployment or adoption","Connect system and destination asymmetrically without labels, UI, logos, or literal branded buildings",("handshake imagery","shipping-box clichés","arrows with labels","logos","centered product render","generic cloud icons"),"The significance includes Microsoft being announced as the first customer, so delivery and adoption matter alongside invention.",HELIOS_SOURCE_REFERENCES),
+ ConceptProfile("industrial-scale-v1","A modular rack-scale system understood as physical industrial infrastructure","Density, assembly, repetition, and human-relative scale distinguish infrastructure from a chip or consumer product","Use repetition, sectional structure, framing, or scale cues; any rack must belong to a broader industrial system",("isolated rack on an empty background","luxury product photography","impossible machinery","science-fiction server chamber","decorative cables","glowing circuitry"),"Helios is a rack-scale industrial system rather than an individual chip or consumer product.",HELIOS_SOURCE_REFERENCES),
+ ConceptProfile("architecture-rivalry-v1","Two distinct engineered system architectures occupying the same field","Different structural logics contrast through construction and organization rather than literal combat","Use parallel, interlocking, diverging, or opposing engineered forms without identifiable branded hardware",("boxing or battle imagery","chessboards","versus symbols","red-versus-green color coding","generic twin towers","explosions","dramatic combat lighting","logos"),"AMD is presenting an alternative integrated architecture intended to compete with Nvidia rack-scale systems.",HELIOS_SOURCE_REFERENCES),
+ ConceptProfile("small-share-large-ambition-v1","A small initial engineered footprint developing into a larger credible infrastructure commitment","Spatial proportion contrasts present position with infrastructure-level ambition without magical transformation","Use proportion and spatial contrast without charts, diagrams, numbers, arrows, or exaggerated success symbolism",("charts","percentage graphics","arrows","magical growth","tiny object becoming a skyscraper","exaggerated success symbolism"),"AMD currently has a small data-center GPU share while making a large infrastructure-level commitment.",HELIOS_SOURCE_REFERENCES),
+)
+if len({x.concept_id for x in _REGISTERED})!=len(_REGISTERED):raise RuntimeError("duplicate_concept_profile")
+CONCEPT_PROFILES:Mapping[str,ConceptProfile]=MappingProxyType({x.concept_id:x for x in _REGISTERED})
+
+def get_concept(concept_id:str)->ConceptProfile:
+ try:return CONCEPT_PROFILES[concept_id]
+ except KeyError as exc:raise KeyError("unknown_concept_profile") from exc


### PR DESCRIPTION
## Summary

Separates experimental editorial visual concepts from rendering-style profiles while leaving production generation byte-identical and version-stable.

Calibration can now form a declarative Cartesian product of styles × concepts × samples. Every private candidate maps to exactly one style, concept, and sample; public manifests and galleries remain blind. Experimental prompts replace the validated brief's central subject, metaphor, composition, and forbidden elements while retaining exact validated source facts and recording both original-brief and concept hashes.

## New concept registry

`tools/tldr_editorial/illustration_concepts.py` registers:

- `integrated-stack-v1`
- `challenger-enters-v1`
- `system-to-buyer-v1`
- `industrial-scale-v1`
- `architecture-rivalry-v1`
- `small-share-large-ambition-v1`

Concepts contain no rendering-style fields. Existing style profiles contain no AMD-specific facts or visual-brief overrides. The AMD anti-default clause is calibration-only.

## CLI

```bash
python -m tools.tldr_editorial calibrate-images \
  --date 2026-07-21 \
  --style-profiles print-graphic-v1,constructed-collage-v1 \
  --concepts integrated-stack-v1,challenger-enters-v1,system-to-buyer-v1,industrial-scale-v1,architecture-rivalry-v1,small-share-large-ambition-v1 \
  --samples-per-combination 1 \
  --output-dir /home/galois/tldr-image-calibration/round-1b \
  --max-images 12
```

`--samples-per-combination` defaults to 1 and accepts 1–3. `--max-images` covers the full Cartesian product. `--profiles` and `--samples-per-profile` remain compatible with the original style-only experiment.

## Gallery

The local blind gallery now uses larger images, at most three desktop columns, one narrow-screen column, source facts once at the top, anonymous IDs below images, identical 3:2 framing, and local click-to-enlarge. It has no remote dependencies and exposes no style, concept, or sample identity.

## Round 1B design

Round 1 produced no production winner. Advance `print-graphic-v1` and `constructed-collage-v1` based on best-sample quality and pair behavior. Cross both with all six concepts for twelve concept-discovery calls, then retain two combinations and generate two additional samples per finalist for four consistency calls. This PR documents but does not execute that experiment.

## Changed files

- `tools/tldr_editorial/illustration_concepts.py`
- `tools/tldr_editorial/calibration.py`
- `tools/tldr_editorial/cli.py`
- `tests_editorial/test_illustration_calibration.py`
- `docs/ILLUSTRATION_CALIBRATION.md`

## Verification

- derive: 46 passed
- raw privacy: 16 passed
- pipeline: 24 passed
- deployment: 17 passed
- editorial: 89 passed
- Worker: 13 passed
- total: 205 passed
- Bash syntax: passed
- strict privacy: 5,939 sources, zero errors/hits
- normalized consistency: passed
- editorial consistency: passed
- Cartesian planning smoke test: 2 styles × 6 concepts × 1 sample, 12 anonymous candidates, zero image/editorial/R2 calls

No image or paid call occurred. No official artifact, production prompt, prompt version, R2 object, frontend, cron, or production checkout changed.
