### PR TITLE
Add explicit illustration calibration combinations

### DIFF
--- a/docs/ILLUSTRATION_CALIBRATION.md
+++ b/docs/ILLUSTRATION_CALIBRATION.md
@@ -53,6 +53,19 @@ python -m tools.tldr_editorial calibrate-images \
 
 The output must be absolute, outside Git, non-symlinked, and empty. The checkout must be clean. CI live runs are forbidden. `--samples-per-combination` defaults to one and accepts one through three; `--max-images` covers styles × concepts × samples. `--profiles` and `--samples-per-profile` remain aliases for the original style-only experiment. Repeated samples receive independent anonymous IDs while using identical prompts and source facts. No candidate is automatically retried; after one failure, it and all unattempted candidates are recorded and paid calls stop.
 
+For a stability experiment that must not generate the Cartesian product, select exact pairs explicitly:
+
+```bash
+python -m tools.tldr_editorial calibrate-images \
+  --date 2026-07-21 \
+  --combinations print-graphic-v1:integrated-stack-v1,constructed-collage-v1:integrated-stack-v1,print-graphic-v1:challenger-enters-v1 \
+  --samples-per-combination 2 \
+  --output-dir /home/galois/tldr-image-calibration/round-1c-stability \
+  --max-images 6
+```
+
+Each comma-separated entry must contain exactly one registered style and one registered concept. Duplicate pairs, malformed or unknown IDs, and mixing `--combinations` with `--style-profiles`, `--profiles`, or `--concepts` are rejected. Legacy `--profiles` cannot be combined with `--concepts`; use `--style-profiles` for Cartesian style × concept experiments.
+
 Outputs are `manifest.json`, private `blind-map.json`, `gallery.html`, `score-template.json`, and (live only) normalized anonymous WebPs. The private map stores style, concept, and sample. The public manifest and gallery expose none. The self-contained `file://` gallery randomizes anonymous candidates, shows source facts once, uses at most three large columns (one on narrow screens), keeps identical 3:2 framing, and offers local click-to-enlarge. Keep `blind-map.json` private until scoring is complete.
 
 ## Human scoring rubric

--- a/tests_editorial/test_illustration_calibration.py
+++ b/tests_editorial/test_illustration_calibration.py
@@ -4,7 +4,8 @@ from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import patch
 from PIL import Image
-from tools.tldr_editorial.calibration import AMD_ANTI_DEFAULT_CLAUSE,CalibrationContext,assemble_experimental_prompt,calibrate_images,read_blind_mapping,run_calibration
+from tools.tldr_editorial.calibration import AMD_ANTI_DEFAULT_CLAUSE,CalibrationContext,assemble_experimental_prompt,calibrate_images,parse_combinations,read_blind_mapping,run_calibration
+from tools.tldr_editorial.cli import main as cli_main
 from tools.tldr_editorial.candidates import Candidate
 from tools.tldr_editorial.core import EditorialError
 from tools.tldr_editorial.image import assemble_prompt,decode_image,normalize_raster
@@ -92,6 +93,28 @@ class CalibrationTests(unittest.TestCase):
   self.assertTrue(all(x.get("original_visual_brief_sha256") and x.get("experimental_concept_sha256") for x in by.values()));self.assertTrue(all(value not in gallery and value not in manifest_text for value in styles+concepts));self.assertNotIn("sample_index",gallery);self.assertNotIn("sample_index",manifest_text)
   self.assertEqual(gallery.count(candidate().title),1);self.assertEqual(gallery.count(candidate().summary),1);self.assertIn("grid-template-columns:repeat(3",gallery);self.assertIn("<dialog",gallery)
   with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_images(date=context().date,profile_ids=styles,concept_ids=concepts,output_dir=self.output("too-many"),max_images=11,samples_per_combination=2,config=config(),context=context())
+ def test_three_explicit_pairs_with_two_samples_are_complete_blind_and_zero_call(self):
+  pairs=[("print-graphic-v1","integrated-stack-v1"),("constructed-collage-v1","integrated-stack-v1"),("print-graphic-v1","challenger-enters-v1")];out=self.output();client=ImageClient();result=calibrate_images(date=context().date,combinations=pairs,output_dir=out,max_images=6,samples_per_combination=2,config=config(),client=client,context=context())
+  self.assertEqual(result["candidate_count"],6);self.assertEqual((result["network_calls"],result["editorial_calls"],result["r2_calls"]),(0,0,0));self.assertEqual((client.image_calls,client.editorial_calls),(0,0))
+  manifest=json.loads((out/"manifest.json").read_text());manifest_text=(out/"manifest.json").read_text();mapping=json.loads((out/"blind-map.json").read_text())["mapping"];gallery=(out/"gallery.html").read_text();records={x["candidate_id"]:x for x in manifest["candidates"]}
+  self.assertEqual(set(records),set(mapping));self.assertTrue(all(set(value)=={"style_profile_id","concept_profile_id","sample_index"} for value in mapping.values()));self.assertEqual({(v["style_profile_id"],v["concept_profile_id"]) for v in mapping.values()},set(pairs))
+  hashes=[]
+  for pair in pairs:
+   members=[candidate_id for candidate_id,value in mapping.items() if (value["style_profile_id"],value["concept_profile_id"])==pair];self.assertEqual({mapping[x]["sample_index"] for x in members},{1,2});pair_hashes={records[x]["prompt_sha256"] for x in members};self.assertEqual(len(pair_hashes),1);hashes.extend(pair_hashes)
+  self.assertEqual(len(set(hashes)),3);self.assertTrue(all(candidate().title in gallery and candidate().summary in gallery for _ in [0]));self.assertTrue(all(token not in gallery and token not in manifest_text for pair in pairs for token in pair));self.assertNotIn("sample_index",gallery);self.assertNotIn("sample_index",manifest_text)
+ def test_explicit_pair_validation_conflicts_and_limit(self):
+  valid=[("print-graphic-v1","integrated-stack-v1")]
+  for value in ("","print-graphic-v1","print-graphic-v1:",":integrated-stack-v1","a:b:c","a:b,"):
+   with self.assertRaises(EditorialError):parse_combinations(value)
+  with self.assertRaisesRegex(EditorialError,"calibration_combinations_required"):calibrate_images(date=context().date,combinations=[],output_dir=self.output("empty-pairs"),max_images=1,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_combination_malformed"):calibrate_images(date=context().date,combinations=[("print-graphic-v1",)],output_dir=self.output("malformed-pair"),max_images=1,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_duplicate_combination"):calibrate_images(date=context().date,combinations=valid*2,output_dir=self.output("dup-pair"),max_images=2,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_combination_style_unknown"):calibrate_images(date=context().date,combinations=[("missing-style","integrated-stack-v1")],output_dir=self.output("style-unknown"),max_images=1,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_combination_concept_unknown"):calibrate_images(date=context().date,combinations=[("print-graphic-v1","missing-concept")],output_dir=self.output("concept-unknown"),max_images=1,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_combination_mode_conflict"):calibrate_images(date=context().date,profile_ids=["print-graphic-v1"],combinations=valid,output_dir=self.output("style-conflict"),max_images=1,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_combination_mode_conflict"):calibrate_images(date=context().date,concept_ids=["integrated-stack-v1"],combinations=valid,output_dir=self.output("concept-conflict"),max_images=1,config=config(),context=context())
+  with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_images(date=context().date,combinations=valid*1+[('constructed-collage-v1','integrated-stack-v1')],output_dir=self.output("pair-limit"),max_images=3,samples_per_combination=2,config=config(),context=context())
+  with patch("sys.stderr",new=io.StringIO()):self.assertEqual(cli_main(["calibrate-images","--date",context().date,"--profiles","print-graphic-v1","--concepts","integrated-stack-v1","--output-dir",str(self.output("legacy-conflict")),"--max-images","1"]),2)
  def test_live_requires_both_flags_ci_is_forbidden_and_limit_is_enforced(self):
   ids=["baseline-v1"]
   for flags in ({"require_live":True},{"acknowledge_cost":True}):

--- a/tools/tldr_editorial/calibration.py
+++ b/tools/tldr_editorial/calibration.py
@@ -134,15 +134,27 @@ def _write_outputs(output:Path,context:CalibrationContext,candidates:list[dict],
  _json(output/"manifest.json",manifest);_json(output/"blind-map.json",blind);_json(output/"score-template.json",score)
  _atomic_bytes(output/"gallery.html",_gallery(order,context).encode(),0o600)
 
-def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile],output:Path,cfg:Config,live:bool,client=None,concepts:Sequence[ConceptProfile]|None=None,samples_per_combination:int=1,samples_per_profile:int|None=None)->dict:
- legacy=concepts is None
+def parse_combinations(value:str)->list[tuple[str,str]]:
+ if not value.strip():raise EditorialError("calibration_combinations_required")
+ pairs=[]
+ for entry in value.split(","):
+  parts=[x.strip() for x in entry.split(":")]
+  if len(parts)!=2 or not all(parts):raise EditorialError("calibration_combination_malformed")
+  pairs.append((parts[0],parts[1]))
+ return pairs
+
+def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile],output:Path,cfg:Config,live:bool,client=None,concepts:Sequence[ConceptProfile]|None=None,combinations:Sequence[tuple[PromptProfile,ConceptProfile]]|None=None,samples_per_combination:int=1,samples_per_profile:int|None=None)->dict:
+ legacy=concepts is None and combinations is None
  if samples_per_profile is not None:
   if not legacy or samples_per_combination!=1:raise EditorialError("calibration_sample_flags_conflict")
   if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
   samples_per_combination=samples_per_profile
  elif not 1<=samples_per_combination<=3:raise EditorialError("calibration_samples_per_combination_invalid")
- selected_concepts=list(concepts) if concepts is not None else [_official_concept(context)]
- assignments=[(style,concept,sample_index) for style in profiles for concept in selected_concepts for sample_index in range(1,samples_per_combination+1)];ids=[]
+ if combinations is not None:pairs=list(combinations)
+ else:
+  selected_concepts=list(concepts) if concepts is not None else [_official_concept(context)]
+  pairs=[(style,concept) for style in profiles for concept in selected_concepts]
+ assignments=[(style,concept,sample_index) for style,concept in pairs for sample_index in range(1,samples_per_combination+1)];ids=[]
  for _ in assignments:
   while True:
    value="candidate-"+secrets.token_hex(4)
@@ -168,26 +180,44 @@ def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile
  _write_outputs(output,context,records,mapping)
  return {"date":context.date,"candidate_count":len(records),"ready_count":sum(x["status"]=="ready" for x in records),"failed_count":sum(x["status"]=="failed" for x in records),"network_calls":network_calls,"editorial_calls":0,"r2_calls":0,"live":live,"success":not failed,"output_dir":str(output)}
 
-def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_images:int,concept_ids:Sequence[str]|None=None,samples_per_combination:int=1,samples_per_profile:int|None=None,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
+def calibrate_images(*,date:str,profile_ids:Sequence[str]|None=None,output_dir:Path,max_images:int,concept_ids:Sequence[str]|None=None,combinations:Sequence[tuple[str,str]]|None=None,samples_per_combination:int=1,samples_per_profile:int|None=None,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
  if not date:raise EditorialError("calibration_date_required")
- if not profile_ids:raise EditorialError("calibration_profiles_required")
- if len(set(profile_ids))!=len(profile_ids):raise EditorialError("calibration_duplicate_profile")
- try:profiles=[get_profile(x) for x in profile_ids]
- except KeyError as exc:raise EditorialError("calibration_profile_unknown") from exc
- concepts=None
- if concept_ids is not None:
-  if not concept_ids:raise EditorialError("calibration_concepts_required")
-  if len(set(concept_ids))!=len(concept_ids):raise EditorialError("calibration_duplicate_concept")
-  try:concepts=[get_concept(x) for x in concept_ids]
-  except KeyError as exc:raise EditorialError("calibration_concept_unknown") from exc
+ explicit=combinations is not None
+ if explicit and (profile_ids is not None or concept_ids is not None):raise EditorialError("calibration_combination_mode_conflict")
+ profiles=[];concepts=None;resolved_combinations=None
+ if explicit:
+  if not combinations:raise EditorialError("calibration_combinations_required")
+  normalized=[]
+  for pair in combinations:
+   if not isinstance(pair,(tuple,list)) or len(pair)!=2 or not all(isinstance(x,str) and x.strip() for x in pair):raise EditorialError("calibration_combination_malformed")
+   normalized.append((pair[0].strip(),pair[1].strip()))
+  if len(set(normalized))!=len(normalized):raise EditorialError("calibration_duplicate_combination")
+  resolved_combinations=[]
+  for style_id,concept_id in normalized:
+   try:style=get_profile(style_id)
+   except KeyError as exc:raise EditorialError("calibration_combination_style_unknown") from exc
+   try:concept=get_concept(concept_id)
+   except KeyError as exc:raise EditorialError("calibration_combination_concept_unknown") from exc
+   resolved_combinations.append((style,concept))
+ else:
+  if not profile_ids:raise EditorialError("calibration_profiles_required")
+  if len(set(profile_ids))!=len(profile_ids):raise EditorialError("calibration_duplicate_profile")
+  try:profiles=[get_profile(x) for x in profile_ids]
+  except KeyError as exc:raise EditorialError("calibration_profile_unknown") from exc
+  if concept_ids is not None:
+   if not concept_ids:raise EditorialError("calibration_concepts_required")
+   if len(set(concept_ids))!=len(concept_ids):raise EditorialError("calibration_duplicate_concept")
+   try:concepts=[get_concept(x) for x in concept_ids]
+   except KeyError as exc:raise EditorialError("calibration_concept_unknown") from exc
  if samples_per_profile is not None:
-  if concepts is not None or samples_per_combination!=1:raise EditorialError("calibration_sample_flags_conflict")
+  if explicit or concepts is not None or samples_per_combination!=1:raise EditorialError("calibration_sample_flags_conflict")
   if not 1<=samples_per_profile<=5:raise EditorialError("calibration_samples_per_profile_invalid")
   samples=samples_per_profile
  else:
   if not 1<=samples_per_combination<=3:raise EditorialError("calibration_samples_per_combination_invalid")
   samples=samples_per_combination
- total=len(profiles)*(len(concepts) if concepts is not None else 1)*samples
+ pair_count=len(resolved_combinations) if explicit else len(profiles)*(len(concepts) if concepts is not None else 1)
+ total=pair_count*samples
  if max_images<1 or total>max_images:raise EditorialError("calibration_image_limit")
  if require_live!=acknowledge_cost:raise EditorialError("calibration_live_flags_required")
  live=require_live and acknowledge_cost
@@ -196,4 +226,4 @@ def calibrate_images(*,date:str,profile_ids:Sequence[str],output_dir:Path,max_im
  if live:cfg.require_openrouter()
  context=context or _context(date,generated,editorial_output,cfg)
  if context.date!=date:raise EditorialError("calibration_context_date_mismatch")
- return run_calibration(context=context,profiles=profiles,concepts=concepts,output=output,cfg=cfg,live=live,client=client,samples_per_combination=samples if samples_per_profile is None else 1,samples_per_profile=samples_per_profile)
+ return run_calibration(context=context,profiles=profiles,concepts=concepts,combinations=resolved_combinations,output=output,cfg=cfg,live=live,client=client,samples_per_combination=samples if samples_per_profile is None else 1,samples_per_profile=samples_per_profile)

--- a/tools/tldr_editorial/cli.py
+++ b/tools/tldr_editorial/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import argparse,json,sys
 from pathlib import Path
 from .artifacts import validate_all
-from .calibration import calibrate_images
+from .calibration import calibrate_images,parse_combinations
 from .config import Config
 from .core import EditorialError
 from .generator import generate
@@ -16,7 +16,7 @@ def parser():
     for x in ("force","retry-image","dry-run","offline","require-live"): g.add_argument("--"+x,action="store_true")
     v=sub.add_parser("validate"); v.add_argument("--all",action="store_true",required=True); v.add_argument("--output",type=Path,default=Path("generated/editorial")); v.add_argument("--generated",type=Path,default=Path("generated")); v.add_argument("--verify-storage",action="store_true")
     s=sub.add_parser("storage-report"); s.add_argument("--output",type=Path,default=Path("generated/editorial")); s.add_argument("--list-r2",action="store_true")
-    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);styles=c.add_mutually_exclusive_group(required=True);styles.add_argument("--style-profiles");styles.add_argument("--profiles");c.add_argument("--concepts");c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);samples=c.add_mutually_exclusive_group();samples.add_argument("--samples-per-combination",type=int);samples.add_argument("--samples-per-profile",type=int);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
+    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);styles=c.add_mutually_exclusive_group();styles.add_argument("--style-profiles");styles.add_argument("--profiles");c.add_argument("--concepts");c.add_argument("--combinations");c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);samples=c.add_mutually_exclusive_group();samples.add_argument("--samples-per-combination",type=int);samples.add_argument("--samples-per-profile",type=int);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
     return p
 
 def main(argv=None):
@@ -26,8 +26,11 @@ def main(argv=None):
             result=generate(generated=a.generated,output=a.output,date=a.date,latest=a.latest or not a.date,offline=a.offline,dry_run=a.dry_run,require_live=a.require_live,force=a.force,retry_image=a.retry_image)
             print(json.dumps(result,sort_keys=True)); return 0
         if a.command=="calibrate-images":
-            style_value=a.style_profiles or a.profiles;ids=[x.strip() for x in style_value.split(",") if x.strip()];concept_ids=[x.strip() for x in a.concepts.split(",") if x.strip()] if a.concepts is not None else None
-            result=calibrate_images(date=a.date,profile_ids=ids,concept_ids=concept_ids,output_dir=a.output_dir,max_images=a.max_images,samples_per_combination=a.samples_per_combination if a.samples_per_combination is not None else 1,samples_per_profile=a.samples_per_profile,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
+            style_value=a.style_profiles or a.profiles
+            if a.combinations is not None and (style_value is not None or a.concepts is not None):raise EditorialError("calibration_combination_mode_conflict")
+            if a.profiles is not None and a.concepts is not None:raise EditorialError("calibration_legacy_profiles_concepts_conflict")
+            ids=[x.strip() for x in style_value.split(",") if x.strip()] if style_value is not None else None;concept_ids=[x.strip() for x in a.concepts.split(",") if x.strip()] if a.concepts is not None else None;combinations=parse_combinations(a.combinations) if a.combinations is not None else None
+            result=calibrate_images(date=a.date,profile_ids=ids,concept_ids=concept_ids,combinations=combinations,output_dir=a.output_dir,max_images=a.max_images,samples_per_combination=a.samples_per_combination if a.samples_per_combination is not None else 1,samples_per_profile=a.samples_per_profile,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
             print(json.dumps(result,sort_keys=True));return 0 if result["success"] else 1
         if a.command=="validate":
             cfg=Config.from_env(); storage=R2Storage(cfg) if a.verify_storage else None


### PR DESCRIPTION
## Summary

Adds explicit style/concept pair selection to the isolated illustration calibration CLI without changing production prompt assembly or generation behavior.

```bash
--combinations style-a:concept-a,style-b:concept-b
```

Each pair resolves exactly one registered style and concept. Sampling and `--max-images` apply to the selected pair count rather than a Cartesian product.

## Validation

The implementation rejects:

- empty or malformed entries
- unknown style or concept IDs
- duplicate pairs
- combinations mixed with `--style-profiles`, `--profiles`, or `--concepts`
- legacy `--profiles` mixed with concepts
- invalid sample counts or totals exceeding `--max-images`

Legacy style-only mode and `--style-profiles` × `--concepts` Cartesian mode remain supported.

## Safety

Explicit mode uses the existing calibration engine and therefore preserves:

- zero-network planning
- no editorial-model or R2 construction/calls
- no official artifact writes
- anonymous candidate IDs and private mappings
- stop-on-first-failure with no retries
- byte-identical production `assemble_prompt()` behavior

## Changed files

- `tools/tldr_editorial/calibration.py`
- `tools/tldr_editorial/cli.py`
- `tests_editorial/test_illustration_calibration.py`
- `docs/ILLUSTRATION_CALIBRATION.md`

## Verification

- derive: 46 passed
- raw privacy: 16 passed
- pipeline: 24 passed
- deployment: 17 passed
- editorial: 91 passed
- Worker: 13 passed
- total: 207 passed
- strict privacy: 5,939 sources, zero errors/hits
- generated and editorial consistency: passed
- Bash syntax: passed

Planning smoke test used exactly:

- `print-graphic-v1:integrated-stack-v1`
- `constructed-collage-v1:integrated-stack-v1`
- `print-graphic-v1:challenger-enters-v1`

with two samples each. It produced six anonymous planned candidates, zero network/editorial/R2 calls, no WebPs, and blind public outputs.

No image or paid call occurred. Production prompts, versions, artifacts, checkout, R2, frontend, and cron remain unchanged.
