### PR TITLE
Add cross-story illustration calibration

### DIFF
--- a/docs/ILLUSTRATION_CALIBRATION.md
+++ b/docs/ILLUSTRATION_CALIBRATION.md
@@ -68,6 +68,20 @@ Each comma-separated entry must contain exactly one registered style and one reg
 
 Outputs are `manifest.json`, private `blind-map.json`, `gallery.html`, `score-template.json`, and (live only) normalized anonymous WebPs. The private map stores style, concept, and sample. The public manifest and gallery expose none. The self-contained `file://` gallery randomizes anonymous candidates, shows source facts once, uses at most three large columns (one on narrow screens), keeps identical 3:2 framing, and offers local click-to-enlarge. Keep `blind-map.json` private until scoring is complete.
 
+## Cross-story calibration
+
+`--story-combinations` runs immutable calibration-only story definitions from `tools/tldr_editorial/calibration_stories.py`, verified against exact normalized records. It does not load or write an official editorial artifact and never calls the editorial model.
+
+```bash
+python -m tools.tldr_editorial calibrate-images \
+  --story-combinations secure-agent-sandboxes-v1@constructed-collage-v1,secure-agent-sandboxes-v1@print-graphic-v1,workers-automation-threshold-v1@constructed-collage-v1,workers-automation-threshold-v1@print-graphic-v1 \
+  --samples-per-combination 1 \
+  --output-dir /home/galois/tldr-image-calibration/cross-story \
+  --max-images 4
+```
+
+Each entry selects one registered story and one rendering style. Entries cannot be mixed with date, profile, concept, or single-story combination options. The private map contains story/style/sample identities; public output labels separate anonymous `Story A` and `Story B` sections, each with its own exact source facts and locally enlargable anonymous candidates.
+
 ## Human scoring rubric
 
 Score every criterion from 1 (poor) to 5 (excellent):

--- a/tests_editorial/test_illustration_calibration.py
+++ b/tests_editorial/test_illustration_calibration.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 import base64,hashlib,io,json,os,subprocess,tempfile,unittest
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError,replace
 from pathlib import Path
 from unittest.mock import patch
 from PIL import Image
-from tools.tldr_editorial.calibration import AMD_ANTI_DEFAULT_CLAUSE,CalibrationContext,assemble_experimental_prompt,calibrate_images,parse_combinations,read_blind_mapping,run_calibration
+from tools.tldr_editorial.calibration import AMD_ANTI_DEFAULT_CLAUSE,CalibrationContext,assemble_experimental_prompt,assemble_story_prompt,calibrate_images,calibrate_story_images,parse_combinations,read_blind_mapping,run_calibration
 from tools.tldr_editorial.cli import main as cli_main
 from tools.tldr_editorial.candidates import Candidate
 from tools.tldr_editorial.core import EditorialError
 from tools.tldr_editorial.image import assemble_prompt,decode_image,normalize_raster
+from tools.tldr_editorial.calibration_stories import STORIES,resolve_story
 from tools.tldr_editorial.illustration_concepts import CONCEPT_PROFILES,ConceptProfile
 from tools.tldr_editorial.illustration_prompts import BASELINE_PREAMBLE,BASELINE_PROFILE,PROMPT_PROFILES,PromptProfile,SHARED_FACTUAL_RESTRICTIONS
 from tools.tldr_editorial.openrouter import Result
@@ -115,6 +116,19 @@ class CalibrationTests(unittest.TestCase):
   with self.assertRaisesRegex(EditorialError,"calibration_combination_mode_conflict"):calibrate_images(date=context().date,concept_ids=["integrated-stack-v1"],combinations=valid,output_dir=self.output("concept-conflict"),max_images=1,config=config(),context=context())
   with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_images(date=context().date,combinations=valid*1+[('constructed-collage-v1','integrated-stack-v1')],output_dir=self.output("pair-limit"),max_images=3,samples_per_combination=2,config=config(),context=context())
   with patch("sys.stderr",new=io.StringIO()):self.assertEqual(cli_main(["calibrate-images","--date",context().date,"--profiles","print-graphic-v1","--concepts","integrated-stack-v1","--output-dir",str(self.output("legacy-conflict")),"--max-images","1"]),2)
+ def test_registered_calibration_stories_resolve_exactly_and_detect_drift(self):
+  generated=Path(__file__).resolve().parents[1]/"generated";self.assertEqual(set(STORIES),{"secure-agent-sandboxes-v1","workers-automation-threshold-v1"})
+  for story in STORIES.values():
+   source=resolve_story(story,generated);self.assertEqual((source.issue_id,source.article_id),(story.issue_id,story.article_id));self.assertEqual(source.title,story.expected_title);self.assertIn(source.summary,assemble_story_prompt(story,source,PROMPT_PROFILES["print-graphic-v1"]))
+  with self.assertRaisesRegex(EditorialError,"calibration_story_title_drift"):resolve_story(replace(next(iter(STORIES.values())),expected_title="drift"),generated)
+  with self.assertRaisesRegex(EditorialError,"calibration_story_summary_drift"):resolve_story(replace(next(iter(STORIES.values())),expected_summary_sha256="sha256:deadbeef"),generated)
+ def test_story_combinations_are_grouped_blind_complete_and_zero_network(self):
+  pairs=[("secure-agent-sandboxes-v1","constructed-collage-v1"),("secure-agent-sandboxes-v1","print-graphic-v1"),("workers-automation-threshold-v1","constructed-collage-v1"),("workers-automation-threshold-v1","print-graphic-v1")];out=self.output();client=ImageClient();generated=Path(__file__).resolve().parents[1]/"generated";result=calibrate_story_images(story_combinations=pairs,output_dir=out,max_images=4,generated=generated,config=config(),client=client)
+  self.assertEqual(result["candidate_count"],4);self.assertEqual((result["network_calls"],result["editorial_calls"],result["r2_calls"]),(0,0,0));self.assertEqual((client.image_calls,client.editorial_calls),(0,0));manifest=json.loads((out/"manifest.json").read_text());mapping=json.loads((out/"blind-map.json").read_text())["mapping"];gallery=(out/"gallery.html").read_text();public=gallery+(out/"manifest.json").read_text();records=[x for group in manifest["story_groups"] for x in group["candidates"]]
+  self.assertEqual(set(mapping),{x["candidate_id"] for x in records});self.assertTrue(all(set(x)=={"story_id","style_profile_id","sample_index"} for x in mapping.values()));self.assertEqual({(x["story_id"],x["style_profile_id"]) for x in mapping.values()},set(pairs));self.assertEqual(len(manifest["story_groups"]),2);self.assertTrue(all(len(x["candidates"])==2 for x in manifest["story_groups"]));self.assertIn("Story A",gallery);self.assertIn("Story B",gallery);self.assertIn("grid-template-columns:repeat(2",gallery);self.assertTrue(all(token not in public for pair in pairs for token in pair));self.assertNotIn("sample_index",public);self.assertFalse(list(out.glob("*.webp")))
+  hashes={(v["story_id"],v["style_profile_id"]):next(x["prompt_sha256"] for x in records if x["candidate_id"]==cid) for cid,v in mapping.items()};self.assertNotEqual(hashes[pairs[0]],hashes[pairs[1]]);self.assertNotEqual(hashes[pairs[0]],hashes[pairs[2]])
+  with self.assertRaisesRegex(EditorialError,"calibration_duplicate_story_combination"):calibrate_story_images(story_combinations=pairs[:1]*2,output_dir=self.output("story-dup"),max_images=2,generated=generated,config=config())
+  with self.assertRaisesRegex(EditorialError,"calibration_image_limit"):calibrate_story_images(story_combinations=pairs,output_dir=self.output("story-limit"),max_images=3,generated=generated,config=config())
  def test_live_requires_both_flags_ci_is_forbidden_and_limit_is_enforced(self):
   ids=["baseline-v1"]
   for flags in ({"require_live":True},{"acknowledge_cost":True}):

--- a/tools/tldr_editorial/calibration.py
+++ b/tools/tldr_editorial/calibration.py
@@ -9,6 +9,7 @@ from .candidates import Candidate,load_date
 from .config import Config
 from .core import EditorialError
 from .image import assemble_prompt,decode_image,normalize_raster
+from .calibration_stories import CalibrationStory,get_story,resolve_story
 from .illustration_concepts import CONCEPT_SCHEMA_VERSION,ConceptProfile,get_concept
 from .illustration_prompts import PROFILE_SCHEMA_VERSION,PromptProfile,get_profile
 from .openrouter import OpenRouterClient
@@ -51,6 +52,10 @@ def assemble_experimental_prompt(context:CalibrationContext,style:PromptProfile,
  if concept.required_source_references and not set(concept.required_source_references).issubset(refs):raise EditorialError("calibration_concept_source_requirement_missing")
  lines=[style.preamble,"","Experimental editorial concept:",f"Factual rationale: {concept.factual_rationale}",f"Central subject: {concept.central_subject_override}",f"Visual metaphor: {concept.visual_metaphor_override}",f"Composition: {concept.composition_override}","Concept-specific forbidden elements: "+(", ".join(concept.forbidden_elements) or "none"),"",AMD_ANTI_DEFAULT_CLAUSE,"","Source stories (use only these exact facts):"]
  for source in context.sources:lines.extend((f"Title: {source.title}",f"Summary: {source.summary}"))
+ return "\n".join(lines).strip()+"\n"
+
+def assemble_story_prompt(story:CalibrationStory,source:Candidate,style:PromptProfile)->str:
+ lines=[style.preamble,"","Calibration editorial concept:",f"Factual rationale: {story.factual_rationale}",f"Central subject: {story.central_subject}",f"Visual metaphor: {story.visual_metaphor}",f"Composition: {story.composition}","Concept-specific forbidden elements: "+", ".join(story.forbidden_elements),"",AMD_ANTI_DEFAULT_CLAUSE,"","Source stories (use only these exact facts):",f"Title: {source.title}",f"Summary: {source.summary}"]
  return "\n".join(lines).strip()+"\n"
 
 def _git_root()->Path:
@@ -179,6 +184,62 @@ def run_calibration(*,context:CalibrationContext,profiles:Sequence[PromptProfile
   except EditorialError as exc:record.update(status="failed",failure_category=str(exc));failed=True
  _write_outputs(output,context,records,mapping)
  return {"date":context.date,"candidate_count":len(records),"ready_count":sum(x["status"]=="ready" for x in records),"failed_count":sum(x["status"]=="failed" for x in records),"network_calls":network_calls,"editorial_calls":0,"r2_calls":0,"live":live,"success":not failed,"output_dir":str(output)}
+
+def _story_gallery(groups:list[dict])->str:
+ sections=[]
+ for group in groups:
+  source=group["source"];cards=[]
+  for record in group["candidates"]:
+   media=f'<button class="image-button" type="button" aria-label="Enlarge {html.escape(record["candidate_id"])}"><img src="{html.escape(record["image_file"])}" alt="Anonymous calibration candidate"></button>' if record.get("image_file") else '<div class="placeholder">No image generated</div>'
+   cards.append(f'<article>{media}<h3>{html.escape(record["candidate_id"])}</h3></article>')
+  sections.append(f'<section class="story"><h2>{html.escape(group["story_group_id"])}</h2><div class="source"><p><strong>{html.escape(source.title)}</strong><br>{html.escape(source.summary)}</p></div><div class="grid">{"".join(cards)}</div></section>')
+ return """<!doctype html><meta charset="utf-8"><title>Blind illustration calibration</title><style>body{font:16px system-ui;margin:2rem auto;max-width:1400px;background:#eee;color:#111;padding:0 1rem}.story{margin:2rem 0}.source,article{background:white;padding:1rem}.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1.5rem}.image-button{display:block;width:100%;padding:0;border:0;background:none;cursor:zoom-in}img,.placeholder{display:block;width:100%;aspect-ratio:3/2;object-fit:cover;background:#ddd}.placeholder{display:grid;place-items:center}h3{font-size:1rem;margin:.75rem 0 0}dialog{border:0;padding:0;background:#111;max-width:95vw}dialog img{width:auto;max-width:95vw;max-height:92vh;aspect-ratio:auto;object-fit:contain}@media(max-width:800px){.grid{grid-template-columns:1fr}}</style><h1>Blind illustration calibration</h1>"""+"".join(sections)+"""<dialog id="zoom"><img alt="Enlarged anonymous candidate"></dialog><script>const d=document.querySelector('#zoom'),z=d.querySelector('img');document.querySelectorAll('.image-button img').forEach(i=>i.parentElement.addEventListener('click',()=>{z.src=i.src;d.showModal()}));d.addEventListener('click',()=>d.close());</script>\n"""
+
+def calibrate_story_images(*,story_combinations:Sequence[tuple[str,str]],output_dir:Path,max_images:int,samples_per_combination:int=1,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),config:Config|None=None,client=None)->dict:
+ if not story_combinations:raise EditorialError("calibration_story_combinations_required")
+ if len(set(story_combinations))!=len(story_combinations):raise EditorialError("calibration_duplicate_story_combination")
+ if not 1<=samples_per_combination<=3:raise EditorialError("calibration_samples_per_combination_invalid")
+ resolved=[]
+ for story_id,style_id in story_combinations:
+  try:story=get_story(story_id)
+  except KeyError as exc:raise EditorialError("calibration_story_unknown") from exc
+  try:style=get_profile(style_id)
+  except KeyError as exc:raise EditorialError("calibration_story_style_unknown") from exc
+  resolved.append((story,style,resolve_story(story,generated)))
+ total=len(resolved)*samples_per_combination
+ if max_images<1 or total>max_images:raise EditorialError("calibration_image_limit")
+ if require_live!=acknowledge_cost:raise EditorialError("calibration_live_flags_required")
+ live=require_live and acknowledge_cost
+ if live and os.getenv("CI"):raise EditorialError("calibration_live_forbidden_in_ci")
+ _require_clean();output=_prepare_output(output_dir,_git_root());cfg=config or Config.from_env()
+ if live:cfg.require_openrouter()
+ story_ids=list(dict.fromkeys(story.story_id for story,style,source in resolved));assignments=[(story,style,source,sample) for story,style,source in resolved for sample in range(1,samples_per_combination+1)];ids=[]
+ for _ in assignments:
+  value="candidate-"+secrets.token_hex(4)
+  while value in ids:value="candidate-"+secrets.token_hex(4)
+  ids.append(value)
+ mapping={cid:{"story_id":story.story_id,"style_profile_id":style.profile_id,"sample_index":sample} for cid,(story,style,source,sample) in zip(ids,assignments)};records=[];failed=False;network_calls=0;image_client=(client or OpenRouterClient(cfg)) if live else None
+ for cid,(story,style,source,sample) in zip(ids,assignments):
+  prompt=assemble_story_prompt(story,source,style);record={"candidate_id":cid,"story_group_id":"Story "+chr(65+story_ids.index(story.story_id)),"status":"planned" if not live else "not_attempted","image_file":None,"sha256":None,"width":None,"height":None,"bytes":None,"prompt_sha256":"sha256:"+hashlib.sha256(prompt.encode()).hexdigest(),"model":cfg.image_model,"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"cost_usd":0.0}};records.append(record)
+  if not live or failed:continue
+  try:
+   network_calls+=1;result=image_client.image(prompt);raw,media=decode_image(result.value,result.media_type);fd,tmp=tempfile.mkstemp(prefix="tldr-calibration-provider-",suffix=".raster")
+   try:
+    os.fchmod(fd,0o600)
+    with os.fdopen(fd,"wb") as handle:handle.write(raw);handle.flush();os.fsync(handle.fileno())
+    image=normalize_raster(Path(tmp),media,cfg.max_provider_image_bytes,cfg.max_image_pixels,cfg.max_image_bytes)
+   finally:
+    try:os.unlink(tmp)
+    except FileNotFoundError:pass
+   filename=cid+".webp";_atomic_bytes(output/filename,image.data);record.update(status="ready",image_file=filename,sha256=image.sha256,width=image.width,height=image.height,bytes=image.bytes,usage=result.usage)
+  except EditorialError as exc:record.update(status="failed",failure_category=str(exc));failed=True
+ groups=[];order=[];unique_stories=[]
+ for story,style,source in resolved:
+  if story.story_id not in {x[0].story_id for x in unique_stories}:unique_stories.append((story,source))
+ for index,(story,source) in enumerate(unique_stories):
+  members=[r for r in records if mapping[r["candidate_id"]]["story_id"]==story.story_id];secrets.SystemRandom().shuffle(members);groups.append({"story_group_id":"Story "+chr(65+index),"source":source,"candidates":members});order.extend(members)
+ manifest={"schema_version":CALIBRATION_SCHEMA_VERSION,"story_schema_version":"1.0.0","model":cfg.image_model,"story_groups":[{"story_group_id":x["story_group_id"],"source_context":[{"title":x["source"].title,"summary":x["source"].summary}],"candidates":x["candidates"]} for x in groups]};score={"schema_version":CALIBRATION_SCHEMA_VERSION,"rubric":RUBRIC,"scores":[{"candidate_id":x["candidate_id"],"hard_rejection":False,"hard_rejection_reasons":[],"ratings":{c["id"]:None for c in RUBRIC["weighted_criteria"]},"first_impression":"","strongest_quality":"","strongest_weakness":"","feels_human_directed":None,"advance_to_round_two":None} for x in order]};_json(output/"manifest.json",manifest);_json(output/"blind-map.json",{"schema_version":CALIBRATION_SCHEMA_VERSION,"mapping":mapping});_json(output/"score-template.json",score);_atomic_bytes(output/"gallery.html",_story_gallery(groups).encode(),0o600)
+ return {"candidate_count":len(records),"ready_count":sum(x["status"]=="ready" for x in records),"failed_count":sum(x["status"]=="failed" for x in records),"network_calls":network_calls,"editorial_calls":0,"r2_calls":0,"live":live,"success":not failed,"output_dir":str(output)}
 
 def calibrate_images(*,date:str,profile_ids:Sequence[str]|None=None,output_dir:Path,max_images:int,concept_ids:Sequence[str]|None=None,combinations:Sequence[tuple[str,str]]|None=None,samples_per_combination:int=1,samples_per_profile:int|None=None,require_live:bool=False,acknowledge_cost:bool=False,generated:Path=Path("generated"),editorial_output:Path=Path("generated/editorial"),config:Config|None=None,client=None,context:CalibrationContext|None=None)->dict:
  if not date:raise EditorialError("calibration_date_required")

--- a/tools/tldr_editorial/calibration_stories.py
+++ b/tools/tldr_editorial/calibration_stories.py
@@ -1,0 +1,39 @@
+"""Immutable calibration-only cross-story visual briefs."""
+from __future__ import annotations
+import hashlib,json
+from dataclasses import dataclass
+from types import MappingProxyType
+from pathlib import Path
+from typing import Mapping
+from .candidates import Candidate,load_date
+from .core import EditorialError
+
+STORY_SCHEMA_VERSION="1.0.0"
+@dataclass(frozen=True)
+class CalibrationStory:
+ story_id:str;date:str;issue_id:str;article_id:str;expected_title:str;expected_summary_sha256:str
+ central_subject:str;visual_metaphor:str;composition:str;forbidden_elements:tuple[str,...];factual_rationale:str;schema_version:str=STORY_SCHEMA_VERSION
+
+_REGISTERED=(
+ CalibrationStory("secure-agent-sandboxes-v1","2026-07-16","tldr-ai:2026-07-16","tldr-ai:2026-07-16:a09","SECURE SANDBOXES FOR AGENTS","sha256:5c2ecf066fd4aa84da6ab56c002dc0c4c5be06f4eb031a19c3f5ed8b3b3e9d94","A protected unit of work moving through an ephemeral layered enclosure.","Nested or adjacent temporary compartments isolate execution, control, and secrets while still allowing one controlled task path.","Use an asymmetrical sectional or layered composition. Show separation, controlled passage, and temporary containment without literal cybersecurity icons.",("heroic computer or server","robot or humanoid agent","giant padlock","shield icon","cloud icon","floating UI","code text","hacker imagery","neon cyberpunk","prison cell","permanent fortress","generic circuit decoration","visible labels or arrows"),"SPACE uses temporary sandboxes and separate control and credential layers for sensitive agent tasks."),
+ CalibrationStory("workers-automation-threshold-v1","2026-07-16","tldr:2026-07-16","tldr:2026-07-16:a11","THE FIGHT OVER HUMANOID ROBOTS HAS SHUT DOWN A CAR FACTORY FOR THE FIRST TIME","sha256:c90c75a05e5ae63335eea4e9515ab709e96a8c75b78d39655c85d7c74932f51a","A temporarily interrupted industrial line shared between human labor and an incoming automated production structure.","A production path reaches a contested transition point. Human collective presence occupies one side while automation enters its future continuation.","Use lateral tension, interruption, spacing, or an unfinished transition. Humans appear as a collective; automation is emerging industrial capability, not a monster.",("giant threatening robot","robot fighting a worker","literal human-versus-robot split screen","protest fist cliché","handshake cliché","violence","strike placards or visible text","company logos","branded cars or robots","dystopian apocalypse","glowing red robot eyes","triumphant automation advertisement","generic factory stock scene"),"Hyundai workers struck over planned humanoid-robot deployment and job security, creating an organizational threshold rather than a simple human-versus-machine battle."),
+)
+STORIES:Mapping[str,CalibrationStory]=MappingProxyType({x.story_id:x for x in _REGISTERED})
+if len(STORIES)!=len(_REGISTERED):raise RuntimeError("duplicate_calibration_story")
+def get_story(story_id:str)->CalibrationStory:
+ try:return STORIES[story_id]
+ except KeyError as exc:raise KeyError("unknown_calibration_story") from exc
+
+def resolve_story(story:CalibrationStory,generated:Path)->Candidate:
+ try:entries=json.loads((generated/"manifest.json").read_text())["issues"]
+ except (OSError,json.JSONDecodeError,KeyError,TypeError) as exc:raise EditorialError("calibration_story_manifest_invalid") from exc
+ entries=[x for x in entries if x.get("date")==story.date and x.get("issue_id")==story.issue_id]
+ if len(entries)!=1 or entries[0].get("parse_status")!="complete":raise EditorialError("calibration_story_issue_incomplete")
+ candidates=[c for c in load_date(generated,story.date) if (c.issue_id,c.article_id)==(story.issue_id,story.article_id)]
+ if len(candidates)!=1:raise EditorialError("calibration_story_reference_invalid")
+ candidate=candidates[0]
+ if candidate.content_class!="editorial":raise EditorialError("calibration_story_not_editorial")
+ if candidate.title!=story.expected_title:raise EditorialError("calibration_story_title_drift")
+ digest="sha256:"+hashlib.sha256(candidate.summary.encode()).hexdigest()
+ if digest!=story.expected_summary_sha256:raise EditorialError("calibration_story_summary_drift")
+ return candidate

--- a/tools/tldr_editorial/cli.py
+++ b/tools/tldr_editorial/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import argparse,json,sys
 from pathlib import Path
 from .artifacts import validate_all
-from .calibration import calibrate_images,parse_combinations
+from .calibration import calibrate_images,calibrate_story_images,parse_combinations
 from .config import Config
 from .core import EditorialError
 from .generator import generate
@@ -16,7 +16,7 @@ def parser():
     for x in ("force","retry-image","dry-run","offline","require-live"): g.add_argument("--"+x,action="store_true")
     v=sub.add_parser("validate"); v.add_argument("--all",action="store_true",required=True); v.add_argument("--output",type=Path,default=Path("generated/editorial")); v.add_argument("--generated",type=Path,default=Path("generated")); v.add_argument("--verify-storage",action="store_true")
     s=sub.add_parser("storage-report"); s.add_argument("--output",type=Path,default=Path("generated/editorial")); s.add_argument("--list-r2",action="store_true")
-    c=sub.add_parser("calibrate-images");c.add_argument("--date",required=True);styles=c.add_mutually_exclusive_group();styles.add_argument("--style-profiles");styles.add_argument("--profiles");c.add_argument("--concepts");c.add_argument("--combinations");c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);samples=c.add_mutually_exclusive_group();samples.add_argument("--samples-per-combination",type=int);samples.add_argument("--samples-per-profile",type=int);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
+    c=sub.add_parser("calibrate-images");c.add_argument("--date");styles=c.add_mutually_exclusive_group();styles.add_argument("--style-profiles");styles.add_argument("--profiles");c.add_argument("--concepts");c.add_argument("--combinations");c.add_argument("--story-combinations");c.add_argument("--output-dir",type=Path,required=True);c.add_argument("--max-images",type=int,required=True);samples=c.add_mutually_exclusive_group();samples.add_argument("--samples-per-combination",type=int);samples.add_argument("--samples-per-profile",type=int);c.add_argument("--require-live",action="store_true");c.add_argument("--acknowledge-cost",action="store_true")
     return p
 
 def main(argv=None):
@@ -27,10 +27,20 @@ def main(argv=None):
             print(json.dumps(result,sort_keys=True)); return 0
         if a.command=="calibrate-images":
             style_value=a.style_profiles or a.profiles
-            if a.combinations is not None and (style_value is not None or a.concepts is not None):raise EditorialError("calibration_combination_mode_conflict")
-            if a.profiles is not None and a.concepts is not None:raise EditorialError("calibration_legacy_profiles_concepts_conflict")
-            ids=[x.strip() for x in style_value.split(",") if x.strip()] if style_value is not None else None;concept_ids=[x.strip() for x in a.concepts.split(",") if x.strip()] if a.concepts is not None else None;combinations=parse_combinations(a.combinations) if a.combinations is not None else None
-            result=calibrate_images(date=a.date,profile_ids=ids,concept_ids=concept_ids,combinations=combinations,output_dir=a.output_dir,max_images=a.max_images,samples_per_combination=a.samples_per_combination if a.samples_per_combination is not None else 1,samples_per_profile=a.samples_per_profile,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
+            if a.story_combinations is not None:
+                if a.date or style_value is not None or a.concepts is not None or a.combinations is not None or a.samples_per_profile is not None:raise EditorialError("calibration_story_mode_conflict")
+                pairs=[]
+                for entry in a.story_combinations.split(","):
+                    parts=[x.strip() for x in entry.split("@")]
+                    if len(parts)!=2 or not all(parts):raise EditorialError("calibration_story_combination_malformed")
+                    pairs.append((parts[0],parts[1]))
+                result=calibrate_story_images(story_combinations=pairs,output_dir=a.output_dir,max_images=a.max_images,samples_per_combination=a.samples_per_combination if a.samples_per_combination is not None else 1,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
+            else:
+                if not a.date:raise EditorialError("calibration_date_required")
+                if a.combinations is not None and (style_value is not None or a.concepts is not None):raise EditorialError("calibration_combination_mode_conflict")
+                if a.profiles is not None and a.concepts is not None:raise EditorialError("calibration_legacy_profiles_concepts_conflict")
+                ids=[x.strip() for x in style_value.split(",") if x.strip()] if style_value is not None else None;concept_ids=[x.strip() for x in a.concepts.split(",") if x.strip()] if a.concepts is not None else None;combinations=parse_combinations(a.combinations) if a.combinations is not None else None
+                result=calibrate_images(date=a.date,profile_ids=ids,concept_ids=concept_ids,combinations=combinations,output_dir=a.output_dir,max_images=a.max_images,samples_per_combination=a.samples_per_combination if a.samples_per_combination is not None else 1,samples_per_profile=a.samples_per_profile,require_live=a.require_live,acknowledge_cost=a.acknowledge_cost)
             print(json.dumps(result,sort_keys=True));return 0 if result["success"] else 1
         if a.command=="validate":
             cfg=Config.from_env(); storage=R2Storage(cfg) if a.verify_storage else None


### PR DESCRIPTION
## Summary

Adds a calibration-only multi-story experiment mode. It compares registered rendering styles across exact normalized source records without an official editorial artifact or any editorial-model call.

## Registered stories

- `secure-agent-sandboxes-v1` → `tldr-ai:2026-07-16:a09`
- `workers-automation-threshold-v1` → `tldr:2026-07-16:a11`

Each immutable story includes exact date/reference/title/summary digest, story-specific visual interpretation, factual rationale, and restrictions. Runtime resolution rejects incomplete issues, non-editorial/sponsored records, reference mismatches, title drift, and summary drift.

## CLI

```bash
python -m tools.tldr_editorial calibrate-images \
  --story-combinations secure-agent-sandboxes-v1@constructed-collage-v1,secure-agent-sandboxes-v1@print-graphic-v1,workers-automation-threshold-v1@constructed-collage-v1,workers-automation-threshold-v1@print-graphic-v1 \
  --samples-per-combination 1 \
  --output-dir /home/galois/tldr-image-calibration/cross-story \
  --max-images 4
```

This mode cannot be mixed with date/profile/concept/single-story combination options. Public output uses anonymous Story A/B groups with exact facts once per group. The private map contains story/style/sample identities.

## Safety

- zero-network planning
- no editorial model or R2 construction/calls
- no official artifact dependency or mutation
- existing cost flags, CI refusal, clean-workspace check, output rules, failure stop, and WebP normalization retained
- production `assemble_prompt()` and prompt versions untouched

## Verification

- derive: 46 passed
- raw privacy: 16 passed
- pipeline: 24 passed
- deployment: 17 passed
- editorial: 93 passed
- Worker: 13 passed
- total: 209 passed
- strict privacy: 5,939 sources, zero errors/hits
- generated/editorial consistency: passed
- Bash syntax: passed
- planning smoke: 4 candidates, two story groups, zero image/editorial/R2 calls, zero WebPs

No image or paid call occurred. Production checkout, prompts, artifacts, R2, frontend, and cron are unchanged.
